### PR TITLE
refactor: small design improvements

### DIFF
--- a/apps/client/src/components/AddressLink.tsx
+++ b/apps/client/src/components/AddressLink.tsx
@@ -1,0 +1,37 @@
+/**
+ * Truncates a Radix address and links to the Radix Dashboard.
+ *
+ * account_tdx_2_12ym...942 → account_...wma942
+ * resource_tdx_2_1t4x...6vn → resource_...cqr6vn
+ */
+export function AddressLink({
+  address,
+  className
+}: {
+  address: string
+  className?: string
+}) {
+  const isStokenet = address.includes('_tdx_2_')
+  const prefix = address.startsWith('account_') ? 'account' : 'resource'
+  const dashboardBase = isStokenet
+    ? 'https://stokenet-dashboard.radixdlt.com'
+    : 'https://dashboard.radixdlt.com'
+  const suffix = prefix === 'resource' ? '/summary' : ''
+  const href = `${dashboardBase}/${prefix}/${address}${suffix}`
+  const truncated = `${prefix}_...${address.slice(-6)}`
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={
+        className ??
+        'font-mono text-xs text-muted-foreground underline decoration-muted-foreground/40 hover:decoration-foreground hover:text-foreground transition-colors'
+      }
+      title={address}
+    >
+      {truncated}
+    </a>
+  )
+}

--- a/apps/client/src/components/AppHeader.tsx
+++ b/apps/client/src/components/AppHeader.tsx
@@ -3,14 +3,15 @@ import ConnectButton from '@/components/ConnectButton'
 
 export function AppHeader({ onMenuClick }: { onMenuClick: () => void }) {
   return (
-    <div className="top-bar">
+    <header className="top-bar">
       <button
         className="lg:hidden mr-auto p-2 rounded-lg hover:bg-accent"
         onClick={onMenuClick}
+        aria-label="Open navigation menu"
       >
         <Menu className="h-5 w-5" />
       </button>
       <ConnectButton />
-    </div>
+    </header>
   )
 }

--- a/apps/client/src/components/Sidebar.tsx
+++ b/apps/client/src/components/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect, useCallback } from 'react'
 import { Link, useMatches } from '@tanstack/react-router'
 import { Result, useAtomValue } from '@effect-atom/atom-react'
 import { Users, FileText, X, Shield, ChevronRight, Plus } from 'lucide-react'
@@ -21,8 +22,6 @@ export function Sidebar({
 
   const teamsResult = useAtomValue(teamsListAtom)
 
-  const activeExpandedTeamId = teamId
-
   const vaultMatch = matches.find(
     (m) => (m.params as { vaultId?: string }).vaultId
   )
@@ -40,6 +39,46 @@ export function Sidebar({
       .onSuccess((t) => t)
       .render() ?? []
 
+  // ── Expand/collapse state (independent of navigation) ──
+  const [expandedTeams, setExpandedTeams] = useState<Set<string>>(new Set())
+  const [expandedVaults, setExpandedVaults] = useState<Set<string>>(new Set())
+
+  // Auto-expand the active team + its vaults on route change
+  useEffect(() => {
+    if (teamId) {
+      setExpandedTeams((prev) => {
+        if (prev.has(teamId)) return prev
+        const next = new Set(prev)
+        next.add(teamId)
+        return next
+      })
+      setExpandedVaults((prev) => {
+        if (prev.has(teamId)) return prev
+        const next = new Set(prev)
+        next.add(teamId)
+        return next
+      })
+    }
+  }, [teamId])
+
+  const toggleTeam = useCallback((id: string) => {
+    setExpandedTeams((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
+
+  const toggleVaults = useCallback((id: string) => {
+    setExpandedVaults((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
+
   return (
     <>
       {open && (
@@ -55,21 +94,22 @@ export function Sidebar({
         }`}
       >
         {/* ── Logo ── */}
-        <div className="flex items-center justify-between h-14 px-5">
-          <Link to="/" className="flex items-center gap-2.5" onClick={onClose}>
+        <div className="flex items-center justify-between h-16 px-5">
+          <Link to="/" className="flex items-center gap-3" onClick={onClose}>
             <Shield
-              className="h-5.5 w-5.5 text-safe-green"
+              className="h-6 w-6 text-safe-green"
               style={{
-                filter: 'drop-shadow(0 0 6px oklch(0.55 0.17 155 / 0.5))',
+                filter: 'drop-shadow(0 0 8px oklch(0.55 0.17 155 / 0.4))',
                 animation: 'shimmer 3s ease-in-out infinite'
               }}
             />
             <span
-              className="text-sm font-medium tracking-wide"
               style={{
                 fontFamily: "'Space Grotesk', sans-serif",
-                color: 'oklch(0.82 0 0)',
-                letterSpacing: '0.04em'
+                fontSize: '15px',
+                fontWeight: 500,
+                color: 'oklch(0.85 0.01 55)',
+                letterSpacing: '0.05em'
               }}
             >
               Radix Vaults
@@ -79,7 +119,7 @@ export function Sidebar({
             className="lg:hidden p-1 rounded-md hover:bg-white/10 transition-colors"
             onClick={onClose}
           >
-            <X className="h-4 w-4" style={{ color: 'oklch(0.6 0 0)' }} />
+            <X className="h-4 w-4" style={{ color: 'oklch(0.55 0.01 55)' }} />
           </button>
         </div>
 
@@ -88,19 +128,19 @@ export function Sidebar({
           className="mx-5 h-px"
           style={{
             background:
-              'linear-gradient(90deg, transparent, oklch(0.25 0.01 155), transparent)'
+              'linear-gradient(90deg, transparent, oklch(0.24 0.015 55), transparent)'
           }}
         />
 
         {/* ── Network badge ── */}
-        <div className="flex items-center gap-2 px-5 py-3">
+        <div className="flex items-center gap-2.5 px-5 py-3.5">
           <span
             className="h-1.5 w-1.5 rounded-full bg-safe-green"
             style={{ animation: 'pulse-dot 2s ease-in-out infinite' }}
           />
           <span
-            className="text-[10px] font-semibold uppercase tracking-wider"
-            style={{ color: 'oklch(0.5 0 0)' }}
+            className="text-[10px] font-semibold uppercase"
+            style={{ color: 'oklch(0.45 0.015 55)', letterSpacing: '0.1em' }}
           >
             Stokenet
           </span>
@@ -108,98 +148,155 @@ export function Sidebar({
 
         {/* ── Navigation ── */}
         <nav className="flex-1 px-3 py-1 space-y-0.5 overflow-y-auto">
-          {/* ── My Teams ── */}
           {teams.length > 0 && (
             <>
-              <div className="sidebar-section-label">My teams</div>
+              {/* ── "My teams" clickable header → home ── */}
+              <Link
+                to="/"
+                onClick={onClose}
+                className={`sidebar-section-label sidebar-section-link${
+                  matches.length === 1 && matches[0]?.fullPath === '/'
+                    ? ' active'
+                    : ''
+                }`}
+              >
+                My teams
+              </Link>
               <div
                 className="mx-2 mb-1 h-px"
                 style={{
                   background:
-                    'linear-gradient(90deg, oklch(0.25 0.01 155), transparent)'
+                    'linear-gradient(90deg, oklch(0.22 0.015 55), transparent)'
                 }}
               />
+
+              {/* ── Team list ── */}
               {teams.map((team) => {
-                const isExpanded = activeExpandedTeamId === team.teamId
+                const isExpanded = expandedTeams.has(team.teamId)
                 const isActiveTeam = teamId === team.teamId
+                const isVaultsExpanded = expandedVaults.has(team.teamId)
+                const isVaultsActive =
+                  isActiveTeam &&
+                  matches.some((m) =>
+                    m.fullPath.startsWith('/teams/$teamId/vaults')
+                  )
+                const isMembersActive =
+                  isActiveTeam &&
+                  matches.some((m) =>
+                    m.fullPath.startsWith('/teams/$teamId/team')
+                  )
+
                 return (
-                  <div
-                    key={team.teamId}
-                    className={
-                      isExpanded
-                        ? 'sidebar-team-group expanded'
-                        : 'sidebar-team-group'
-                    }
-                  >
-                    <Link
-                      to="/teams/$teamId"
-                      params={{ teamId: team.teamId }}
-                      onClick={onClose}
-                      className={`sidebar-nav-item sidebar-team-toggle${
-                        isActiveTeam ? ' active' : ''
-                      }`}
+                  <div key={team.teamId} className="sidebar-team-group">
+                    {/* Team row */}
+                    <div
+                      className={`sidebar-row sidebar-row--team${isActiveTeam ? ' active' : ''}`}
                     >
-                      <ChevronRight
-                        className={`sidebar-nav-icon sidebar-chevron${
-                          isExpanded ? ' expanded' : ''
-                        }`}
-                      />
-                      <Users className="sidebar-nav-icon" />
-                      <span className="truncate">{team.name}</span>
-                    </Link>
-                    {isExpanded && (
-                      <>
-                        <Link
-                          to="/teams/$teamId/vaults"
-                          params={{ teamId: team.teamId }}
-                          onClick={onClose}
-                          className={`sidebar-nav-item sidebar-nav-nested${
-                            isActiveTeam &&
-                            matches.some((m) =>
-                              m.fullPath.startsWith('/teams/$teamId/vaults')
-                            )
-                              ? ' active'
-                              : ''
-                          }`}
-                        >
-                          Vaults
-                        </Link>
-                        <TeamVaults
-                          teamId={team.teamId}
-                          activeVaultId={isActiveTeam ? vaultId : undefined}
-                          onClose={onClose}
+                      <span
+                        className="sidebar-chevron-area"
+                        onClick={() => toggleTeam(team.teamId)}
+                      >
+                        <ChevronRight
+                          className={`sidebar-chevron${isExpanded ? ' expanded' : ''}`}
                         />
+                      </span>
+                      <Link
+                        to="/teams/$teamId"
+                        params={{ teamId: team.teamId }}
+                        onClick={onClose}
+                        className="sidebar-row-link"
+                      >
+                        <Users className="sidebar-icon" />
+                        <span className="truncate">{team.name}</span>
+                      </Link>
+                    </div>
+
+                    {/* Team children */}
+                    {isExpanded && (
+                      <div
+                        className={`sidebar-children${isActiveTeam ? ' active' : ''}`}
+                      >
+                        {/* Members */}
                         <Link
                           to="/teams/$teamId/team"
                           params={{ teamId: team.teamId }}
                           onClick={onClose}
-                          className={`sidebar-nav-item sidebar-nav-nested${
-                            isActiveTeam &&
-                            matches.some((m) =>
-                              m.fullPath.startsWith('/teams/$teamId/team')
-                            )
-                              ? ' active'
-                              : ''
-                          }`}
+                          className={`sidebar-row sidebar-row--child sidebar-row--leaf${isMembersActive ? ' active' : ''}`}
                         >
                           Members
                         </Link>
-                      </>
+
+                        {/* Vaults (collapsible) */}
+                        <div
+                          className={`sidebar-row sidebar-row--child${isVaultsActive ? ' active' : ''}`}
+                        >
+                          <span
+                            className="sidebar-chevron-area"
+                            onClick={() => toggleVaults(team.teamId)}
+                          >
+                            <ChevronRight
+                              className={`sidebar-chevron${isVaultsExpanded ? ' expanded' : ''}`}
+                            />
+                          </span>
+                          <Link
+                            to="/teams/$teamId/vaults"
+                            params={{ teamId: team.teamId }}
+                            onClick={onClose}
+                            className="sidebar-row-link"
+                          >
+                            Vaults
+                          </Link>
+                        </div>
+
+                        {isVaultsExpanded && (
+                          <div
+                            className={`sidebar-children sidebar-children--deep${isVaultsActive ? ' active' : ''}`}
+                          >
+                            <TeamVaults
+                              teamId={team.teamId}
+                              activeVaultId={isActiveTeam ? vaultId : undefined}
+                              onClose={onClose}
+                            />
+                            {session && (
+                              <Link
+                                to="/teams/$teamId/vaults/create"
+                                params={{ teamId: team.teamId }}
+                                onClick={onClose}
+                                className={`sidebar-row sidebar-row--vault${
+                                  isActiveTeam &&
+                                  matches.some(
+                                    (m) =>
+                                      m.fullPath ===
+                                      '/teams/$teamId/vaults/create'
+                                  )
+                                    ? ' active'
+                                    : ''
+                                }`}
+                              >
+                                <Plus className="sidebar-icon" />
+                                <span>Create vault</span>
+                              </Link>
+                            )}
+                          </div>
+                        )}
+                      </div>
                     )}
                   </div>
                 )
               })}
+
+              {/* Create team */}
               {session && (
                 <Link
                   to="/teams/create"
                   onClick={onClose}
-                  className={`sidebar-nav-item${
+                  className={`sidebar-row sidebar-row--team${
                     matches.some((m) => m.fullPath === '/teams/create')
                       ? ' active'
                       : ''
                   }`}
                 >
-                  <Plus className="sidebar-nav-icon" />
+                  <Plus className="sidebar-icon" />
                   Create team
                 </Link>
               )}
@@ -209,44 +306,75 @@ export function Sidebar({
 
         {/* ── Current vault ── */}
         {teamId && vaultId && (
-          <div className="px-3 pb-4">
-            <div className="vault-card space-y-3">
-              <div>
-                <p
-                  className="text-[10px] font-semibold uppercase tracking-wider"
-                  style={{ color: 'oklch(0.5 0 0)' }}
-                >
-                  Current Vault
-                </p>
-                <p
-                  className="mt-1.5 text-sm font-medium"
-                  style={{ color: 'oklch(0.85 0 0)' }}
-                >
-                  Vault
-                </p>
-                <p
-                  className="text-[11px] font-mono truncate"
-                  style={{ color: 'oklch(0.45 0.02 155)' }}
-                >
-                  {vaultId.slice(0, 12)}...{vaultId.slice(-8)}
-                </p>
-              </div>
-              {session && (
-                <Link
-                  to="/teams/$teamId/vaults/$vaultId/proposals/new"
-                  params={{ teamId: teamId!, vaultId }}
-                  onClick={onClose}
-                  className="vault-card-btn"
-                >
-                  <FileText className="h-3.5 w-3.5" />
-                  New Proposal
-                </Link>
-              )}
-            </div>
-          </div>
+          <CurrentVaultCard
+            teamId={teamId}
+            vaultId={vaultId}
+            session={session}
+            onClose={onClose}
+          />
         )}
       </aside>
     </>
+  )
+}
+
+function CurrentVaultCard({
+  teamId,
+  vaultId,
+  session,
+  onClose
+}: {
+  teamId: string
+  vaultId: string
+  session: boolean | object | null
+  onClose: () => void
+}) {
+  const vaultsResult = useAtomValue(vaultsListAtom(teamId))
+  const vaults =
+    Result.builder(vaultsResult)
+      .onSuccess((v) => v)
+      .render() ?? []
+
+  const vault = vaults.find((v) => v.accountAddress === vaultId)
+  const vaultName =
+    vault?.name ?? vaultId.slice(0, 12) + '...' + vaultId.slice(-8)
+
+  return (
+    <div className="px-3 pb-4">
+      <div className="vault-card space-y-3">
+        <div>
+          <p
+            className="text-[10px] font-semibold uppercase tracking-wider"
+            style={{ color: 'oklch(0.45 0.015 55)' }}
+          >
+            Current Vault
+          </p>
+          <p
+            className="mt-1.5 text-sm font-medium truncate"
+            style={{ color: 'oklch(0.87 0.01 55)' }}
+          >
+            {vaultName}
+          </p>
+          <p
+            className="text-[11px] font-mono truncate"
+            style={{ color: 'oklch(0.42 0.03 145)' }}
+          >
+            {vaultId.slice(0, 12)}...{vaultId.slice(-8)}
+          </p>
+        </div>
+        {session && (
+          <Link
+            to="/teams/$teamId/vaults/$vaultId/proposals/new"
+            params={{ teamId, vaultId }}
+            onClick={onClose}
+            className="vault-card-btn"
+          >
+            <FileText className="h-3.5 w-3.5" />
+            New Proposal
+          </Link>
+        )}
+      </div>
+    </div>
   )
 }
 
@@ -275,7 +403,7 @@ function TeamVaults({
           to="/teams/$teamId/vaults/$vaultId"
           params={{ teamId, vaultId: vault.accountAddress }}
           onClick={onClose}
-          className={`sidebar-nav-item sidebar-nav-vault${
+          className={`sidebar-row sidebar-row--vault${
             activeVaultId === vault.accountAddress ? ' active' : ''
           }`}
         >

--- a/apps/client/src/components/Sidebar.tsx
+++ b/apps/client/src/components/Sidebar.tsx
@@ -61,6 +61,15 @@ export function Sidebar({
     }
   }, [teamId])
 
+  useEffect(() => {
+    if (!open) return
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleEscape)
+    return () => document.removeEventListener('keydown', handleEscape)
+  }, [open, onClose])
+
   const toggleTeam = useCallback((id: string) => {
     setExpandedTeams((prev) => {
       const next = new Set(prev)
@@ -85,6 +94,7 @@ export function Sidebar({
         <div
           className="fixed inset-0 z-40 bg-black/30 lg:hidden"
           onClick={onClose}
+          role="presentation"
         />
       )}
 
@@ -116,8 +126,9 @@ export function Sidebar({
             </span>
           </Link>
           <button
-            className="lg:hidden p-1 rounded-md hover:bg-white/10 transition-colors"
+            className="lg:hidden p-2 rounded-md hover:bg-white/10 transition-colors"
             onClick={onClose}
+            aria-label="Close navigation"
           >
             <X className="h-4 w-4" style={{ color: 'oklch(0.55 0.01 55)' }} />
           </button>
@@ -140,7 +151,7 @@ export function Sidebar({
           />
           <span
             className="text-[10px] font-semibold uppercase"
-            style={{ color: 'oklch(0.45 0.015 55)', letterSpacing: '0.1em' }}
+            style={{ color: 'oklch(0.55 0.015 55)', letterSpacing: '0.1em' }}
           >
             Stokenet
           </span>
@@ -192,14 +203,21 @@ export function Sidebar({
                     <div
                       className={`sidebar-row sidebar-row--team${isActiveTeam ? ' active' : ''}`}
                     >
-                      <span
+                      <button
+                        type="button"
                         className="sidebar-chevron-area"
                         onClick={() => toggleTeam(team.teamId)}
+                        aria-expanded={isExpanded}
+                        aria-label={
+                          isExpanded
+                            ? `Collapse ${team.name}`
+                            : `Expand ${team.name}`
+                        }
                       >
                         <ChevronRight
                           className={`sidebar-chevron${isExpanded ? ' expanded' : ''}`}
                         />
-                      </span>
+                      </button>
                       <Link
                         to="/teams/$teamId"
                         params={{ teamId: team.teamId }}
@@ -230,14 +248,21 @@ export function Sidebar({
                         <div
                           className={`sidebar-row sidebar-row--child${isVaultsActive ? ' active' : ''}`}
                         >
-                          <span
+                          <button
+                            type="button"
                             className="sidebar-chevron-area"
                             onClick={() => toggleVaults(team.teamId)}
+                            aria-expanded={isVaultsExpanded}
+                            aria-label={
+                              isVaultsExpanded
+                                ? 'Collapse vaults'
+                                : 'Expand vaults'
+                            }
                           >
                             <ChevronRight
                               className={`sidebar-chevron${isVaultsExpanded ? ' expanded' : ''}`}
                             />
-                          </span>
+                          </button>
                           <Link
                             to="/teams/$teamId/vaults"
                             params={{ teamId: team.teamId }}

--- a/apps/client/src/components/transaction-preview.tsx
+++ b/apps/client/src/components/transaction-preview.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react'
 import { useAtom } from '@effect-atom/atom-react'
 import { Exit } from 'effect'
 import { previewProposal } from '@/atom/proposals'
+import { AddressLink } from '@/components/AddressLink'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
@@ -58,19 +59,14 @@ export function TransactionPreviewCard({ manifest }: { manifest: string }) {
 
   return (
     <Card>
-      <CardHeader className="flex flex-row items-center justify-between">
+      <CardHeader className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div>
           <CardTitle>Transaction Preview</CardTitle>
           <p className="text-sm text-muted-foreground">
             Simulate execution to estimate fees and check for errors.
           </p>
         </div>
-        <Button
-          onClick={handlePreview}
-          disabled={loading}
-          variant="outline"
-          size="sm"
-        >
+        <Button onClick={handlePreview} disabled={loading} variant="outline">
           {loading ? 'Previewing...' : 'Run Preview'}
         </Button>
       </CardHeader>
@@ -144,27 +140,12 @@ export function TransactionPreviewCard({ manifest }: { manifest: string }) {
   )
 }
 
-const DASHBOARD_BASE =
-  Number(import.meta.env.VITE_NETWORK_ID ?? '2') === 1
-    ? 'https://dashboard.radixdlt.com'
-    : 'https://stokenet-dashboard.radixdlt.com'
-
-function dashboardUrl(address: string) {
-  if (address.startsWith('account_'))
-    return `${DASHBOARD_BASE}/account/${address}`
-  if (address.startsWith('resource_'))
-    return `${DASHBOARD_BASE}/resource/${address}`
-  return `${DASHBOARD_BASE}/component/${address}`
-}
-
 function ResourceChanges({ changes }: { changes: ResourceChange[] }) {
   const sorted = [...changes].sort(
     (a, b) =>
       a.accountAddress.localeCompare(b.accountAddress) ||
       a.resourceAddress.localeCompare(b.resourceAddress)
   )
-
-  const truncate = (addr: string) => `${addr.slice(0, 12)}...${addr.slice(-8)}`
 
   return (
     <div className="space-y-2">
@@ -184,27 +165,11 @@ function ResourceChanges({ changes }: { changes: ResourceChange[] }) {
             const isNegative = change.amount.startsWith('-')
             return (
               <TableRow key={i}>
-                <TableCell className="font-mono text-xs">
-                  <a
-                    href={dashboardUrl(change.accountAddress)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="underline decoration-muted-foreground/40 hover:decoration-foreground"
-                    title={change.accountAddress}
-                  >
-                    {truncate(change.accountAddress)}
-                  </a>
+                <TableCell>
+                  <AddressLink address={change.accountAddress} />
                 </TableCell>
-                <TableCell className="font-mono text-xs">
-                  <a
-                    href={dashboardUrl(change.resourceAddress)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="underline decoration-muted-foreground/40 hover:decoration-foreground"
-                    title={change.resourceAddress}
-                  >
-                    {truncate(change.resourceAddress)}
-                  </a>
+                <TableCell>
+                  <AddressLink address={change.resourceAddress} />
                 </TableCell>
                 <TableCell
                   className={`text-right font-mono text-xs font-medium ${

--- a/apps/client/src/components/ui/button.tsx
+++ b/apps/client/src/components/ui/button.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { cn } from '@/lib/utils'
 
 export const buttonVariants = cva(
-  'inline-flex items-center justify-center rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center rounded-xl text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {
@@ -12,13 +12,13 @@ export const buttonVariants = cva(
         secondary:
           'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
         outline:
-          'border border-input bg-white text-foreground hover:bg-accent hover:text-accent-foreground',
+          'border border-input bg-card text-foreground hover:bg-accent hover:text-accent-foreground',
         ghost: 'text-foreground hover:bg-accent hover:text-accent-foreground'
       },
       size: {
-        default: 'h-9 px-4 py-2',
-        sm: 'h-8 rounded-lg px-3',
-        lg: 'h-10 rounded-lg px-8'
+        default: 'h-10 px-5 py-2',
+        sm: 'h-9 rounded-xl px-4',
+        lg: 'h-11 rounded-xl px-8'
       }
     },
     defaultVariants: {

--- a/apps/client/src/components/ui/card.tsx
+++ b/apps/client/src/components/ui/card.tsx
@@ -8,7 +8,7 @@ export const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      'rounded-lg border border-border bg-white shadow-[0_1px_3px_rgba(0,0,0,0.04),0_1px_2px_rgba(0,0,0,0.06)]',
+      'rounded-xl border border-border bg-card shadow-[0_2px_6px_rgba(0,0,0,0.03),0_1px_2px_rgba(0,0,0,0.04)]',
       className
     )}
     {...props}
@@ -22,7 +22,7 @@ export const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn('flex flex-col space-y-1.5 p-6', className)}
+    className={cn('flex flex-col space-y-2 p-7', className)}
     {...props}
   />
 ))
@@ -34,7 +34,7 @@ export const CardTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <h3
     ref={ref}
-    className={cn('text-xl font-medium tracking-tight', className)}
+    className={cn('text-[1.35rem] font-semibold tracking-tight', className)}
     {...props}
   />
 ))
@@ -56,6 +56,6 @@ export const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn('p-6 pt-3', className)} {...props} />
+  <div ref={ref} className={cn('p-7 pt-3', className)} {...props} />
 ))
 CardContent.displayName = 'CardContent'

--- a/apps/client/src/components/ui/table.tsx
+++ b/apps/client/src/components/ui/table.tsx
@@ -48,7 +48,7 @@ export const TableRow = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <tr
     ref={ref}
-    className={cn('transition-colors hover:bg-accent/50', className)}
+    className={cn('transition-colors hover:bg-accent/70', className)}
     {...props}
   />
 ))
@@ -61,7 +61,7 @@ export const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      'h-10 px-4 text-left align-middle text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground',
+      'h-11 px-4 text-left align-middle text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground whitespace-nowrap',
       className
     )}
     {...props}
@@ -73,6 +73,10 @@ export const TableCell = React.forwardRef<
   HTMLTableCellElement,
   React.TdHTMLAttributes<HTMLTableCellElement>
 >(({ className, ...props }, ref) => (
-  <td ref={ref} className={cn('p-4 align-middle', className)} {...props} />
+  <td
+    ref={ref}
+    className={cn('px-4 py-4.5 align-middle whitespace-nowrap', className)}
+    {...props}
+  />
 ))
 TableCell.displayName = 'TableCell'

--- a/apps/client/src/hooks/useNames.ts
+++ b/apps/client/src/hooks/useNames.ts
@@ -1,0 +1,21 @@
+import { Result, useAtomValue } from '@effect-atom/atom-react'
+import { teamsListAtom } from '@/atom/teams'
+import { vaultsListAtom } from '@/atom/vaults'
+
+export function useTeamName(teamId: string): string {
+  const teamsResult = useAtomValue(teamsListAtom)
+  const teams =
+    Result.builder(teamsResult)
+      .onSuccess((t) => t)
+      .render() ?? []
+  return teams.find((t) => t.teamId === teamId)?.name ?? 'Team'
+}
+
+export function useVaultName(teamId: string, vaultId: string): string {
+  const vaultsResult = useAtomValue(vaultsListAtom(teamId))
+  const vaults =
+    Result.builder(vaultsResult)
+      .onSuccess((v) => v)
+      .render() ?? []
+  return vaults.find((v) => v.accountAddress === vaultId)?.name ?? 'Vault'
+}

--- a/apps/client/src/lib/radixDappToolkit.ts
+++ b/apps/client/src/lib/radixDappToolkit.ts
@@ -29,7 +29,7 @@ export class RadixDappToolkit extends Context.Tag('RadixDappToolkit')<
       })
 
       rdt.walletApi.setRequestData(
-        DataRequestBuilder.accounts().atLeast(1).withProof()
+        DataRequestBuilder.accounts().exactly(1).withProof()
       )
 
       const client = yield* AppApiClient

--- a/apps/client/src/routes/__root.tsx
+++ b/apps/client/src/routes/__root.tsx
@@ -46,7 +46,7 @@ function RootComponent() {
         <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
         <div className="main-content">
           <AppHeader onMenuClick={() => setSidebarOpen(true)} />
-          <div className="p-8">
+          <div className="p-4 sm:p-6 lg:p-8">
             <Outlet />
           </div>
         </div>

--- a/apps/client/src/routes/__root.tsx
+++ b/apps/client/src/routes/__root.tsx
@@ -46,7 +46,7 @@ function RootComponent() {
         <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
         <div className="main-content">
           <AppHeader onMenuClick={() => setSidebarOpen(true)} />
-          <div className="p-6">
+          <div className="p-8">
             <Outlet />
           </div>
         </div>

--- a/apps/client/src/routes/index.tsx
+++ b/apps/client/src/routes/index.tsx
@@ -40,7 +40,7 @@ function HomePage() {
           <div className="flex gap-2">
             <ClientOnly
               fallback={
-                <Button variant="outline" disabled>
+                <Button variant="outline" disabled aria-label="Refresh">
                   <RefreshCw className="h-4 w-4" />
                 </Button>
               }
@@ -76,7 +76,7 @@ function HomePage() {
 function RefreshButton() {
   const refresh = useAtomRefresh(teamsListAtom)
   return (
-    <Button variant="outline" onClick={() => refresh()}>
+    <Button variant="outline" onClick={() => refresh()} aria-label="Refresh">
       <RefreshCw className="h-4 w-4" />
     </Button>
   )

--- a/apps/client/src/routes/index.tsx
+++ b/apps/client/src/routes/index.tsx
@@ -19,7 +19,8 @@ import {
   TableHeader,
   TableRow
 } from '@/components/ui/table'
-import { Plus, Users } from 'lucide-react'
+import { Plus, Users, RefreshCw } from 'lucide-react'
+import { AddressLink } from '@/components/AddressLink'
 
 export const Route = createFileRoute('/')({
   component: HomePage
@@ -29,7 +30,7 @@ function HomePage() {
   return (
     <main className="max-w-5xl space-y-6">
       <Card>
-        <CardHeader className="flex flex-row items-start justify-between gap-4">
+        <CardHeader className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
           <div>
             <CardTitle className="text-2xl">Teams</CardTitle>
             <CardDescription>
@@ -40,7 +41,7 @@ function HomePage() {
             <ClientOnly
               fallback={
                 <Button variant="outline" disabled>
-                  Refresh
+                  <RefreshCw className="h-4 w-4" />
                 </Button>
               }
             >
@@ -76,7 +77,7 @@ function RefreshButton() {
   const refresh = useAtomRefresh(teamsListAtom)
   return (
     <Button variant="outline" onClick={() => refresh()}>
-      Refresh
+      <RefreshCw className="h-4 w-4" />
     </Button>
   )
 }
@@ -95,7 +96,7 @@ function CreateTeamButton() {
     <Link to="/teams/create">
       <Button>
         <Plus className="mr-2 h-4 w-4" />
-        Create Team
+        Create
       </Button>
     </Link>
   )
@@ -167,13 +168,12 @@ function TeamsListSection() {
                         params={{ teamId: team.teamId }}
                         className="flex items-center gap-2"
                       >
-                        <Users className="h-4 w-4 text-muted-foreground" />
-                        {team.name}
+                        <Users className="h-4 w-4 shrink-0 text-muted-foreground" />
+                        <span className="truncate">{team.name}</span>
                       </Link>
                     </TableCell>
-                    <TableCell className="font-mono text-xs">
-                      {team.badgeAddress.slice(0, 20)}...
-                      {team.badgeAddress.slice(-8)}
+                    <TableCell>
+                      <AddressLink address={team.badgeAddress} />
                     </TableCell>
                   </TableRow>
                 ))}

--- a/apps/client/src/routes/teams/$teamId/index.tsx
+++ b/apps/client/src/routes/teams/$teamId/index.tsx
@@ -1,6 +1,13 @@
 import { Result, useAtomRefresh, useAtomValue } from '@effect-atom/atom-react'
-import { createFileRoute, Link, ClientOnly } from '@tanstack/react-router'
+import {
+  createFileRoute,
+  Link,
+  ClientOnly,
+  useNavigate
+} from '@tanstack/react-router'
 import { pendingProposalsAtom } from '@/atom/pendingProposals'
+import { useTeamName } from '@/hooks/useNames'
+import { RefreshCw } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -42,20 +49,21 @@ const typeLabel: Record<string, string> = {
 
 function DashboardPage() {
   const { teamId } = Route.useParams()
+  const teamName = useTeamName(teamId)
   return (
     <main className="max-w-5xl space-y-6">
-      <div className="flex items-center justify-between gap-4">
-        <nav className="text-sm text-muted-foreground">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <nav className="text-sm text-muted-foreground sm:min-h-10 flex items-center flex-wrap">
           <Link to="/" className="hover:text-foreground">
-            Home
+            My Teams
           </Link>
           <span className="mx-2">/</span>
-          <span className="text-foreground font-medium">Dashboard</span>
+          <span className="text-foreground font-medium">{teamName}</span>
         </nav>
         <ClientOnly
           fallback={
             <Button variant="outline" disabled>
-              Refresh
+              <RefreshCw className="h-4 w-4" />
             </Button>
           }
         >
@@ -88,7 +96,7 @@ function RefreshButton() {
   const refresh = useAtomRefresh(pendingProposalsAtom(teamId))
   return (
     <Button variant="outline" onClick={refresh}>
-      Refresh
+      <RefreshCw className="h-4 w-4" />
     </Button>
   )
 }
@@ -111,6 +119,50 @@ function proposalLink(
     to: '/teams/$teamId/team/proposals/$proposalId' as const,
     params: { teamId, proposalId: String(proposal.id) }
   }
+}
+
+function ClickableProposalRow({
+  teamId,
+  proposal: p
+}: {
+  teamId: string
+  proposal: {
+    id: number
+    type: string
+    entityAddress: string
+    entityName?: string | null
+    status: string
+    createdBy: string
+    createdByName?: string | null
+    createdAt: string
+  }
+}) {
+  const navigate = useNavigate()
+  const link = proposalLink(teamId, p)
+  return (
+    <TableRow
+      className="cursor-pointer"
+      onClick={() => navigate({ to: link.to, params: link.params })}
+    >
+      <TableCell className="font-medium">#{p.id}</TableCell>
+      <TableCell>
+        <Badge variant="outline">{typeLabel[p.type] ?? p.type}</Badge>
+      </TableCell>
+      <TableCell className="text-sm">
+        {p.entityName ??
+          `${p.entityAddress.slice(0, 16)}...${p.entityAddress.slice(-6)}`}
+      </TableCell>
+      <TableCell>
+        <Badge variant={statusVariant[p.status] ?? 'outline'}>{p.status}</Badge>
+      </TableCell>
+      <TableCell className="font-mono text-xs">
+        {p.createdByName ?? `${p.createdBy.slice(0, 20)}...`}
+      </TableCell>
+      <TableCell className="text-xs text-muted-foreground">
+        {new Date(p.createdAt).toLocaleString()}
+      </TableCell>
+    </TableRow>
+  )
 }
 
 function PendingProposalsList({ teamId }: { teamId: string }) {
@@ -171,42 +223,13 @@ function PendingProposalsList({ teamId }: { teamId: string }) {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {proposals.map((p) => {
-                  const link = proposalLink(teamId, p)
-                  return (
-                    <TableRow key={p.id}>
-                      <TableCell>
-                        <Link
-                          to={link.to}
-                          params={link.params}
-                          className="font-medium underline decoration-muted-foreground/40 hover:decoration-foreground"
-                        >
-                          #{p.id}
-                        </Link>
-                      </TableCell>
-                      <TableCell>
-                        <Badge variant="outline">
-                          {typeLabel[p.type] ?? p.type}
-                        </Badge>
-                      </TableCell>
-                      <TableCell className="text-sm">
-                        {p.entityName ??
-                          `${p.entityAddress.slice(0, 16)}...${p.entityAddress.slice(-6)}`}
-                      </TableCell>
-                      <TableCell>
-                        <Badge variant={statusVariant[p.status] ?? 'outline'}>
-                          {p.status}
-                        </Badge>
-                      </TableCell>
-                      <TableCell className="font-mono text-xs">
-                        {p.createdByName ?? `${p.createdBy.slice(0, 20)}...`}
-                      </TableCell>
-                      <TableCell className="text-xs text-muted-foreground">
-                        {new Date(p.createdAt).toLocaleString()}
-                      </TableCell>
-                    </TableRow>
-                  )
-                })}
+                {proposals.map((p) => (
+                  <ClickableProposalRow
+                    key={p.id}
+                    teamId={teamId}
+                    proposal={p}
+                  />
+                ))}
               </TableBody>
             </Table>
           </CardContent>

--- a/apps/client/src/routes/teams/$teamId/index.tsx
+++ b/apps/client/src/routes/teams/$teamId/index.tsx
@@ -62,7 +62,7 @@ function DashboardPage() {
         </nav>
         <ClientOnly
           fallback={
-            <Button variant="outline" disabled>
+            <Button variant="outline" disabled aria-label="Refresh">
               <RefreshCw className="h-4 w-4" />
             </Button>
           }
@@ -95,7 +95,7 @@ function RefreshButton() {
   const { teamId } = Route.useParams()
   const refresh = useAtomRefresh(pendingProposalsAtom(teamId))
   return (
-    <Button variant="outline" onClick={refresh}>
+    <Button variant="outline" onClick={refresh} aria-label="Refresh">
       <RefreshCw className="h-4 w-4" />
     </Button>
   )
@@ -142,7 +142,15 @@ function ClickableProposalRow({
   return (
     <TableRow
       className="cursor-pointer"
+      tabIndex={0}
+      role="link"
       onClick={() => navigate({ to: link.to, params: link.params })}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          navigate({ to: link.to, params: link.params })
+        }
+      }}
     >
       <TableCell className="font-medium">#{p.id}</TableCell>
       <TableCell>
@@ -155,10 +163,10 @@ function ClickableProposalRow({
       <TableCell>
         <Badge variant={statusVariant[p.status] ?? 'outline'}>{p.status}</Badge>
       </TableCell>
-      <TableCell className="font-mono text-xs">
+      <TableCell className="hidden sm:table-cell font-mono text-xs">
         {p.createdByName ?? `${p.createdBy.slice(0, 20)}...`}
       </TableCell>
-      <TableCell className="text-xs text-muted-foreground">
+      <TableCell className="hidden sm:table-cell text-xs text-muted-foreground">
         {new Date(p.createdAt).toLocaleString()}
       </TableCell>
     </TableRow>
@@ -218,8 +226,12 @@ function PendingProposalsList({ teamId }: { teamId: string }) {
                   <TableHead>Type</TableHead>
                   <TableHead>Entity</TableHead>
                   <TableHead>Status</TableHead>
-                  <TableHead>Created By</TableHead>
-                  <TableHead>Created</TableHead>
+                  <TableHead className="hidden sm:table-cell">
+                    Created By
+                  </TableHead>
+                  <TableHead className="hidden sm:table-cell">
+                    Created
+                  </TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>

--- a/apps/client/src/routes/teams/$teamId/team/add-member.tsx
+++ b/apps/client/src/routes/teams/$teamId/team/add-member.tsx
@@ -175,7 +175,7 @@ function AddMemberForm({ teamId }: { teamId: string }) {
               placeholder="account_tdx_2_1..."
               value={accountAddress}
               onChange={(e) => setAccountAddress(e.target.value)}
-              className="w-full rounded-lg border border-input bg-card px-3 py-2 font-mono text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+              className="w-full rounded-lg border border-input bg-card px-3 py-2 font-mono text-sm outline-none focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring"
             />
           </div>
 
@@ -191,7 +191,7 @@ function AddMemberForm({ teamId }: { teamId: string }) {
               placeholder="Alice"
               value={memberName}
               onChange={(e) => setMemberName(e.target.value)}
-              className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+              className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring"
             />
             <p className="text-xs text-muted-foreground">
               A human-readable name for this team member (stored on-ledger in
@@ -210,7 +210,7 @@ function AddMemberForm({ teamId }: { teamId: string }) {
               placeholder="resource_tdx_2_...ed25sg...:[hex]"
               value={virtualBadge}
               onChange={(e) => setVirtualBadge(e.target.value)}
-              className="w-full rounded-lg border border-input bg-card px-3 py-2 font-mono text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+              className="w-full rounded-lg border border-input bg-card px-3 py-2 font-mono text-sm outline-none focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring"
             />
             <p className="text-xs text-muted-foreground">
               The new member&apos;s signature virtual badge NonFungibleGlobalId.
@@ -228,7 +228,7 @@ function AddMemberForm({ teamId }: { teamId: string }) {
               min={1}
               value={badgeThreshold || team.threshold}
               onChange={(e) => setBadgeThreshold(e.target.value)}
-              className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+              className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring"
             />
             <p className="text-xs text-muted-foreground">
               Current threshold: {team.threshold}. The team will have{' '}
@@ -255,7 +255,7 @@ function AddMemberForm({ teamId }: { teamId: string }) {
                         [vault.accountAddress]: e.target.value
                       }))
                     }
-                    className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                    className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring"
                   />
                 </div>
               ))}
@@ -263,7 +263,10 @@ function AddMemberForm({ teamId }: { teamId: string }) {
           )}
 
           {error && (
-            <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-900">
+            <div
+              role="alert"
+              className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-900"
+            >
               {error}
             </div>
           )}

--- a/apps/client/src/routes/teams/$teamId/team/add-member.tsx
+++ b/apps/client/src/routes/teams/$teamId/team/add-member.tsx
@@ -13,6 +13,8 @@ import {
 } from '@tanstack/react-router'
 import { Cause, Exit, Option } from 'effect'
 import { useState } from 'react'
+import { useTeamName } from '@/hooks/useNames'
+import { AddressLink } from '@/components/AddressLink'
 import { teamOverviewAtom } from '@/atom/team'
 import {
   createAddMemberProposal,
@@ -35,11 +37,20 @@ export const Route = createFileRoute('/teams/$teamId/team/add-member')({
 
 function AddMemberPage() {
   const { teamId } = Route.useParams()
+  const teamName = useTeamName(teamId)
   return (
     <main className="max-w-5xl space-y-6">
-      <nav className="text-sm text-muted-foreground">
+      <nav className="text-sm text-muted-foreground sm:min-h-10 flex items-center flex-wrap">
         <Link to="/" className="hover:text-foreground">
-          Home
+          My Teams
+        </Link>
+        <span className="mx-2">/</span>
+        <Link
+          to="/teams/$teamId"
+          params={{ teamId }}
+          className="hover:text-foreground"
+        >
+          {teamName}
         </Link>
         <span className="mx-2">/</span>
         <Link
@@ -47,7 +58,7 @@ function AddMemberPage() {
           params={{ teamId }}
           className="hover:text-foreground"
         >
-          Team
+          Members
         </Link>
         <span className="mx-2">/</span>
         <span className="text-foreground font-medium">Add Member</span>
@@ -164,7 +175,7 @@ function AddMemberForm({ teamId }: { teamId: string }) {
               placeholder="account_tdx_2_1..."
               value={accountAddress}
               onChange={(e) => setAccountAddress(e.target.value)}
-              className="w-full rounded-lg border border-input bg-white px-3 py-2 font-mono text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+              className="w-full rounded-lg border border-input bg-card px-3 py-2 font-mono text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
             />
           </div>
 
@@ -180,7 +191,7 @@ function AddMemberForm({ teamId }: { teamId: string }) {
               placeholder="Alice"
               value={memberName}
               onChange={(e) => setMemberName(e.target.value)}
-              className="w-full rounded-lg border border-input bg-white px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+              className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
             />
             <p className="text-xs text-muted-foreground">
               A human-readable name for this team member (stored on-ledger in
@@ -199,7 +210,7 @@ function AddMemberForm({ teamId }: { teamId: string }) {
               placeholder="resource_tdx_2_...ed25sg...:[hex]"
               value={virtualBadge}
               onChange={(e) => setVirtualBadge(e.target.value)}
-              className="w-full rounded-lg border border-input bg-white px-3 py-2 font-mono text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+              className="w-full rounded-lg border border-input bg-card px-3 py-2 font-mono text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
             />
             <p className="text-xs text-muted-foreground">
               The new member&apos;s signature virtual badge NonFungibleGlobalId.
@@ -217,7 +228,7 @@ function AddMemberForm({ teamId }: { teamId: string }) {
               min={1}
               value={badgeThreshold || team.threshold}
               onChange={(e) => setBadgeThreshold(e.target.value)}
-              className="w-full rounded-lg border border-input bg-white px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+              className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
             />
             <p className="text-xs text-muted-foreground">
               Current threshold: {team.threshold}. The team will have{' '}
@@ -230,11 +241,9 @@ function AddMemberForm({ teamId }: { teamId: string }) {
               <p className="text-sm font-medium">Per-Vault Thresholds</p>
               {vaults.map((vault) => (
                 <div key={vault.accountAddress} className="space-y-1">
-                  <label className="text-xs text-muted-foreground">
-                    {vault.name}{' '}
-                    <span className="font-mono">
-                      ({vault.accountAddress.slice(0, 20)}...)
-                    </span>
+                  <label className="text-xs text-muted-foreground flex items-center gap-1.5">
+                    {vault.name} (<AddressLink address={vault.accountAddress} />
+                    )
                   </label>
                   <input
                     type="number"
@@ -246,7 +255,7 @@ function AddMemberForm({ teamId }: { teamId: string }) {
                         [vault.accountAddress]: e.target.value
                       }))
                     }
-                    className="w-full rounded-lg border border-input bg-white px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                    className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
                   />
                 </div>
               ))}
@@ -261,7 +270,7 @@ function AddMemberForm({ teamId }: { teamId: string }) {
 
           <div className="flex gap-3">
             <Button type="submit" disabled={submitting}>
-              {submitting ? 'Creating...' : 'Create Add-Member Proposal'}
+              {submitting ? 'Creating...' : 'Propose Member Add'}
             </Button>
             <Link to="/teams/$teamId/team" params={{ teamId }}>
               <Button type="button" variant="outline">

--- a/apps/client/src/routes/teams/$teamId/team/change-threshold.tsx
+++ b/apps/client/src/routes/teams/$teamId/team/change-threshold.tsx
@@ -161,7 +161,7 @@ function ChangeThresholdForm({ teamId }: { teamId: string }) {
               required
               value={vaultAddress}
               onChange={(e) => setVaultAddress(e.target.value)}
-              className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+              className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring"
             >
               <option value="">Select a vault...</option>
               {vaults.map((v) => (
@@ -183,12 +183,15 @@ function ChangeThresholdForm({ teamId }: { teamId: string }) {
               min={1}
               value={threshold}
               onChange={(e) => setThreshold(e.target.value)}
-              className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+              className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring"
             />
           </div>
 
           {error && (
-            <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-900">
+            <div
+              role="alert"
+              className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-900"
+            >
               {error}
             </div>
           )}

--- a/apps/client/src/routes/teams/$teamId/team/change-threshold.tsx
+++ b/apps/client/src/routes/teams/$teamId/team/change-threshold.tsx
@@ -13,6 +13,7 @@ import {
 } from '@tanstack/react-router'
 import { Cause, Exit, Option } from 'effect'
 import { useState } from 'react'
+import { useTeamName } from '@/hooks/useNames'
 import {
   createChangeThresholdProposal,
   teamProposalListAtom
@@ -43,11 +44,20 @@ export const Route = createFileRoute('/teams/$teamId/team/change-threshold')({
 
 function ChangeThresholdPage() {
   const { teamId } = Route.useParams()
+  const teamName = useTeamName(teamId)
   return (
     <main className="max-w-5xl space-y-6">
-      <nav className="text-sm text-muted-foreground">
+      <nav className="text-sm text-muted-foreground sm:min-h-10 flex items-center flex-wrap">
         <Link to="/" className="hover:text-foreground">
-          Home
+          My Teams
+        </Link>
+        <span className="mx-2">/</span>
+        <Link
+          to="/teams/$teamId"
+          params={{ teamId }}
+          className="hover:text-foreground"
+        >
+          {teamName}
         </Link>
         <span className="mx-2">/</span>
         <Link
@@ -55,7 +65,7 @@ function ChangeThresholdPage() {
           params={{ teamId }}
           className="hover:text-foreground"
         >
-          Team
+          Members
         </Link>
         <span className="mx-2">/</span>
         <span className="text-foreground font-medium">Change Threshold</span>
@@ -151,12 +161,12 @@ function ChangeThresholdForm({ teamId }: { teamId: string }) {
               required
               value={vaultAddress}
               onChange={(e) => setVaultAddress(e.target.value)}
-              className="w-full rounded-lg border border-input bg-white px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+              className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
             >
               <option value="">Select a vault...</option>
               {vaults.map((v) => (
                 <option key={v.accountAddress} value={v.accountAddress}>
-                  {v.name} ({v.accountAddress.slice(0, 20)}...)
+                  {v.name} (account_...{v.accountAddress.slice(-6)})
                 </option>
               ))}
             </select>
@@ -173,7 +183,7 @@ function ChangeThresholdForm({ teamId }: { teamId: string }) {
               min={1}
               value={threshold}
               onChange={(e) => setThreshold(e.target.value)}
-              className="w-full rounded-lg border border-input bg-white px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+              className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
             />
           </div>
 

--- a/apps/client/src/routes/teams/$teamId/team/index.tsx
+++ b/apps/client/src/routes/teams/$teamId/team/index.tsx
@@ -57,7 +57,7 @@ function TeamPage() {
           </Link>
           <ClientOnly
             fallback={
-              <Button variant="outline" disabled>
+              <Button variant="outline" disabled aria-label="Refresh">
                 <RefreshCw className="h-4 w-4" />
               </Button>
             }
@@ -78,7 +78,7 @@ function RefreshTeamButton() {
   const { teamId } = Route.useParams()
   const refresh = useAtomRefresh(teamOverviewAtom(teamId))
   return (
-    <Button variant="outline" onClick={refresh}>
+    <Button variant="outline" onClick={refresh} aria-label="Refresh">
       <RefreshCw className="h-4 w-4" />
     </Button>
   )
@@ -183,9 +183,15 @@ function TeamContent({ teamId }: { teamId: string }) {
               <TableHeader>
                 <TableRow>
                   <TableHead>Name</TableHead>
-                  <TableHead>Key Type</TableHead>
-                  <TableHead>Badge ID</TableHead>
-                  <TableHead>Account Address</TableHead>
+                  <TableHead className="hidden sm:table-cell">
+                    Key Type
+                  </TableHead>
+                  <TableHead className="hidden sm:table-cell">
+                    Badge ID
+                  </TableHead>
+                  <TableHead className="hidden sm:table-cell">
+                    Account Address
+                  </TableHead>
                   <TableHead />
                 </TableRow>
               </TableHeader>
@@ -193,13 +199,13 @@ function TeamContent({ teamId }: { teamId: string }) {
                 {overview.badgeHolders.map((holder) => (
                   <TableRow key={holder.holderAddress}>
                     <TableCell className="font-medium">{holder.name}</TableCell>
-                    <TableCell>
+                    <TableCell className="hidden sm:table-cell">
                       <Badge variant="outline">{holder.keyType}</Badge>
                     </TableCell>
-                    <TableCell className="font-mono text-xs">
+                    <TableCell className="hidden sm:table-cell font-mono text-xs">
                       {holder.localId}
                     </TableCell>
-                    <TableCell>
+                    <TableCell className="hidden sm:table-cell">
                       <AddressLink address={holder.holderAddress} />
                     </TableCell>
                     <TableCell>

--- a/apps/client/src/routes/teams/$teamId/team/index.tsx
+++ b/apps/client/src/routes/teams/$teamId/team/index.tsx
@@ -1,6 +1,9 @@
 import { Result, useAtomRefresh, useAtomValue } from '@effect-atom/atom-react'
 import { createFileRoute, Link, ClientOnly } from '@tanstack/react-router'
 import { teamOverviewAtom } from '@/atom/team'
+import { useTeamName } from '@/hooks/useNames'
+import { AddressLink } from '@/components/AddressLink'
+import { RefreshCw } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -26,27 +29,36 @@ export const Route = createFileRoute('/teams/$teamId/team/')({
 
 function TeamPage() {
   const { teamId } = Route.useParams()
+  const teamName = useTeamName(teamId)
   return (
     <main className="max-w-5xl space-y-6">
-      <div className="flex items-center justify-between gap-4">
-        <nav className="text-sm text-muted-foreground">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <nav className="text-sm text-muted-foreground sm:min-h-10 flex items-center flex-wrap">
           <Link to="/" className="hover:text-foreground">
-            Home
+            My Teams
           </Link>
           <span className="mx-2">/</span>
-          <span className="text-foreground font-medium">Team</span>
+          <Link
+            to="/teams/$teamId"
+            params={{ teamId }}
+            className="hover:text-foreground"
+          >
+            {teamName}
+          </Link>
+          <span className="mx-2">/</span>
+          <span className="text-foreground font-medium">Members</span>
         </nav>
         <div className="flex gap-2">
           <Link to="/teams/$teamId/team/proposals" params={{ teamId }}>
-            <Button variant="outline">Team Proposals</Button>
+            <Button variant="outline">Proposals</Button>
           </Link>
           <Link to="/teams/$teamId/team/add-member" params={{ teamId }}>
-            <Button>Add Member</Button>
+            <Button className="whitespace-nowrap">Add Member</Button>
           </Link>
           <ClientOnly
             fallback={
               <Button variant="outline" disabled>
-                Refresh
+                <RefreshCw className="h-4 w-4" />
               </Button>
             }
           >
@@ -67,7 +79,7 @@ function RefreshTeamButton() {
   const refresh = useAtomRefresh(teamOverviewAtom(teamId))
   return (
     <Button variant="outline" onClick={refresh}>
-      Refresh
+      <RefreshCw className="h-4 w-4" />
     </Button>
   )
 }
@@ -100,8 +112,8 @@ function TeamContent({ teamId }: { teamId: string }) {
         <Card>
           <CardHeader>
             <CardTitle className="text-2xl">Team Overview</CardTitle>
-            <CardDescription className="font-mono text-xs">
-              {overview.teamMemberBadgeAddress}
+            <CardDescription>
+              <AddressLink address={overview.teamMemberBadgeAddress} />
             </CardDescription>
           </CardHeader>
           <CardContent className="grid gap-3 sm:grid-cols-2">
@@ -187,8 +199,8 @@ function TeamContent({ teamId }: { teamId: string }) {
                     <TableCell className="font-mono text-xs">
                       {holder.localId}
                     </TableCell>
-                    <TableCell className="font-mono text-xs">
-                      {holder.holderAddress}
+                    <TableCell>
+                      <AddressLink address={holder.holderAddress} />
                     </TableCell>
                     <TableCell>
                       <Link

--- a/apps/client/src/routes/teams/$teamId/team/proposals/$proposalId.tsx
+++ b/apps/client/src/routes/teams/$teamId/team/proposals/$proposalId.tsx
@@ -9,6 +9,9 @@ import type { TeamProposalDetail } from '@radix-vaults/shared'
 import { ProposalId } from '@radix-vaults/shared'
 import { createFileRoute, Link, ClientOnly } from '@tanstack/react-router'
 import { Exit } from 'effect'
+import { useTeamName } from '@/hooks/useNames'
+import { AddressLink } from '@/components/AddressLink'
+import { RefreshCw } from 'lucide-react'
 import { sessionAtom } from '@/atom/auth'
 import {
   TeamProposalDetailKey,
@@ -68,12 +71,21 @@ const TERMINAL_STATUSES = new Set(['committed', 'failed', 'expired', 'invalid'])
 
 function TeamProposalDetailPage() {
   const { teamId, proposalId } = Route.useParams()
+  const teamName = useTeamName(teamId)
 
   return (
     <main className="max-w-5xl space-y-6">
-      <nav className="text-sm text-muted-foreground">
+      <nav className="text-sm text-muted-foreground sm:min-h-10 flex items-center flex-wrap">
         <Link to="/" className="hover:text-foreground">
-          Home
+          My Teams
+        </Link>
+        <span className="mx-2">/</span>
+        <Link
+          to="/teams/$teamId"
+          params={{ teamId }}
+          className="hover:text-foreground"
+        >
+          {teamName}
         </Link>
         <span className="mx-2">/</span>
         <Link
@@ -81,7 +93,7 @@ function TeamProposalDetailPage() {
           params={{ teamId }}
           className="hover:text-foreground"
         >
-          Team
+          Members
         </Link>
         <span className="mx-2">/</span>
         <Link
@@ -157,7 +169,7 @@ function TeamProposalDetailContent({ teamId }: { teamId: string }) {
     .onSuccess((proposal) => (
       <>
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between">
+          <CardHeader className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
             <div>
               <CardTitle className="text-2xl">
                 Team Proposal #{proposal.id}
@@ -166,13 +178,11 @@ function TeamProposalDetailContent({ teamId }: { teamId: string }) {
                 <Badge variant="outline" className="mr-2">
                   {typeLabel[proposal.type] ?? proposal.type}
                 </Badge>
-                <span className="font-mono text-xs">
-                  {proposal.entityAddress}
-                </span>
+                <AddressLink address={proposal.entityAddress} />
               </CardDescription>
             </div>
             <Button variant="outline" onClick={refresh}>
-              Refresh
+              <RefreshCw className="h-4 w-4" />
             </Button>
           </CardHeader>
           <CardContent className="grid gap-3 sm:grid-cols-3">
@@ -302,7 +312,7 @@ function SignatureProgressCard({
 
   return (
     <Card>
-      <CardHeader className="flex flex-row items-center justify-between">
+      <CardHeader className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div>
           <CardTitle>Signature Progress</CardTitle>
           <CardDescription>
@@ -385,7 +395,7 @@ function SubmitCard({
 
   return (
     <Card className="border-green-200 bg-green-50/80">
-      <CardHeader className="flex flex-row items-center justify-between">
+      <CardHeader className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div>
           <CardTitle>Ready to Submit</CardTitle>
           <CardDescription>
@@ -439,7 +449,7 @@ function TransactionInfoCard({
 
   return (
     <Card>
-      <CardHeader className="flex flex-row items-center justify-between">
+      <CardHeader className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div>
           <CardTitle>Transaction</CardTitle>
           <CardDescription>

--- a/apps/client/src/routes/teams/$teamId/team/proposals/$proposalId.tsx
+++ b/apps/client/src/routes/teams/$teamId/team/proposals/$proposalId.tsx
@@ -181,7 +181,7 @@ function TeamProposalDetailContent({ teamId }: { teamId: string }) {
                 <AddressLink address={proposal.entityAddress} />
               </CardDescription>
             </div>
-            <Button variant="outline" onClick={refresh}>
+            <Button variant="outline" onClick={refresh} aria-label="Refresh">
               <RefreshCw className="h-4 w-4" />
             </Button>
           </CardHeader>

--- a/apps/client/src/routes/teams/$teamId/team/proposals/index.tsx
+++ b/apps/client/src/routes/teams/$teamId/team/proposals/index.tsx
@@ -77,7 +77,7 @@ function TeamProposalsPage() {
         </nav>
         <ClientOnly
           fallback={
-            <Button variant="outline" disabled>
+            <Button variant="outline" disabled aria-label="Refresh">
               <RefreshCw className="h-4 w-4" />
             </Button>
           }
@@ -110,7 +110,7 @@ function RefreshButton() {
   const { teamId } = Route.useParams()
   const refresh = useAtomRefresh(teamProposalListAtom(teamId))
   return (
-    <Button variant="outline" onClick={refresh}>
+    <Button variant="outline" onClick={refresh} aria-label="Refresh">
       <RefreshCw className="h-4 w-4" />
     </Button>
   )
@@ -168,8 +168,12 @@ function TeamProposalsList({ teamId }: { teamId: string }) {
                   <TableHead>ID</TableHead>
                   <TableHead>Type</TableHead>
                   <TableHead>Status</TableHead>
-                  <TableHead>Created By</TableHead>
-                  <TableHead>Created</TableHead>
+                  <TableHead className="hidden sm:table-cell">
+                    Created By
+                  </TableHead>
+                  <TableHead className="hidden sm:table-cell">
+                    Created
+                  </TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -194,10 +198,10 @@ function TeamProposalsList({ teamId }: { teamId: string }) {
                         {p.status}
                       </Badge>
                     </TableCell>
-                    <TableCell className="font-mono text-xs">
+                    <TableCell className="hidden sm:table-cell font-mono text-xs">
                       {p.createdByName ?? `${p.createdBy.slice(0, 20)}...`}
                     </TableCell>
-                    <TableCell className="text-xs text-muted-foreground">
+                    <TableCell className="hidden sm:table-cell text-xs text-muted-foreground">
                       {new Date(p.createdAt).toLocaleString()}
                     </TableCell>
                   </TableRow>

--- a/apps/client/src/routes/teams/$teamId/team/proposals/index.tsx
+++ b/apps/client/src/routes/teams/$teamId/team/proposals/index.tsx
@@ -1,6 +1,8 @@
 import { Result, useAtomRefresh, useAtomValue } from '@effect-atom/atom-react'
 import { createFileRoute, Link, ClientOnly } from '@tanstack/react-router'
 import { teamProposalListAtom } from '@/atom/teamProposals'
+import { useTeamName } from '@/hooks/useNames'
+import { RefreshCw } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -46,12 +48,21 @@ const typeLabel: Record<string, string> = {
 
 function TeamProposalsPage() {
   const { teamId } = Route.useParams()
+  const teamName = useTeamName(teamId)
   return (
     <main className="max-w-5xl space-y-6">
-      <div className="flex items-center justify-between gap-4">
-        <nav className="text-sm text-muted-foreground">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <nav className="text-sm text-muted-foreground sm:min-h-10 flex items-center flex-wrap">
           <Link to="/" className="hover:text-foreground">
-            Home
+            My Teams
+          </Link>
+          <span className="mx-2">/</span>
+          <Link
+            to="/teams/$teamId"
+            params={{ teamId }}
+            className="hover:text-foreground"
+          >
+            {teamName}
           </Link>
           <span className="mx-2">/</span>
           <Link
@@ -59,7 +70,7 @@ function TeamProposalsPage() {
             params={{ teamId }}
             className="hover:text-foreground"
           >
-            Team
+            Members
           </Link>
           <span className="mx-2">/</span>
           <span className="text-foreground font-medium">Team Proposals</span>
@@ -67,7 +78,7 @@ function TeamProposalsPage() {
         <ClientOnly
           fallback={
             <Button variant="outline" disabled>
-              Refresh
+              <RefreshCw className="h-4 w-4" />
             </Button>
           }
         >
@@ -100,7 +111,7 @@ function RefreshButton() {
   const refresh = useAtomRefresh(teamProposalListAtom(teamId))
   return (
     <Button variant="outline" onClick={refresh}>
-      Refresh
+      <RefreshCw className="h-4 w-4" />
     </Button>
   )
 }

--- a/apps/client/src/routes/teams/$teamId/team/remove-member.tsx
+++ b/apps/client/src/routes/teams/$teamId/team/remove-member.tsx
@@ -12,6 +12,8 @@ import {
 } from '@tanstack/react-router'
 import { Cause, Exit, Option } from 'effect'
 import { useEffect, useState } from 'react'
+import { useTeamName } from '@/hooks/useNames'
+import { AddressLink } from '@/components/AddressLink'
 import { teamOverviewAtom } from '@/atom/team'
 import {
   createRemoveMemberProposal,
@@ -43,11 +45,20 @@ export const Route = createFileRoute('/teams/$teamId/team/remove-member')({
 
 function RemoveMemberPage() {
   const { teamId } = Route.useParams()
+  const teamName = useTeamName(teamId)
   return (
     <main className="max-w-5xl space-y-6">
-      <nav className="text-sm text-muted-foreground">
+      <nav className="text-sm text-muted-foreground sm:min-h-10 flex items-center flex-wrap">
         <Link to="/" className="hover:text-foreground">
-          Home
+          My Teams
+        </Link>
+        <span className="mx-2">/</span>
+        <Link
+          to="/teams/$teamId"
+          params={{ teamId }}
+          className="hover:text-foreground"
+        >
+          {teamName}
         </Link>
         <span className="mx-2">/</span>
         <Link
@@ -55,7 +66,7 @@ function RemoveMemberPage() {
           params={{ teamId }}
           className="hover:text-foreground"
         >
-          Team
+          Members
         </Link>
         <span className="mx-2">/</span>
         <span className="text-foreground font-medium">Remove Member</span>
@@ -183,7 +194,7 @@ function RemoveMemberForm({ teamId }: { teamId: string }) {
               required
               value={selectedVirtualBadge}
               onChange={(e) => setSelectedVirtualBadge(e.target.value)}
-              className="w-full rounded-lg border border-input bg-white px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+              className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
             >
               <option value="">Select a member...</option>
               {team.badgeHolders.map((holder) => (
@@ -235,7 +246,7 @@ function RemoveMemberForm({ teamId }: { teamId: string }) {
               max={newSignerCount}
               value={badgeThreshold || Math.min(team.threshold, newSignerCount)}
               onChange={(e) => setBadgeThreshold(e.target.value)}
-              className="w-full rounded-lg border border-input bg-white px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+              className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
             />
             <p className="text-xs text-muted-foreground">
               Current threshold: {team.threshold}. After removal:{' '}
@@ -248,11 +259,9 @@ function RemoveMemberForm({ teamId }: { teamId: string }) {
               <p className="text-sm font-medium">Per-Vault Thresholds</p>
               {vaults.map((vault) => (
                 <div key={vault.accountAddress} className="space-y-1">
-                  <label className="text-xs text-muted-foreground">
-                    {vault.name}{' '}
-                    <span className="font-mono">
-                      ({vault.accountAddress.slice(0, 20)}...)
-                    </span>
+                  <label className="text-xs text-muted-foreground flex items-center gap-1.5">
+                    {vault.name} (<AddressLink address={vault.accountAddress} />
+                    )
                   </label>
                   <input
                     type="number"
@@ -265,7 +274,7 @@ function RemoveMemberForm({ teamId }: { teamId: string }) {
                         [vault.accountAddress]: e.target.value
                       }))
                     }
-                    className="w-full rounded-lg border border-input bg-white px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                    className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
                   />
                 </div>
               ))}

--- a/apps/client/src/routes/teams/$teamId/team/remove-member.tsx
+++ b/apps/client/src/routes/teams/$teamId/team/remove-member.tsx
@@ -194,7 +194,7 @@ function RemoveMemberForm({ teamId }: { teamId: string }) {
               required
               value={selectedVirtualBadge}
               onChange={(e) => setSelectedVirtualBadge(e.target.value)}
-              className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+              className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring"
             >
               <option value="">Select a member...</option>
               {team.badgeHolders.map((holder) => (
@@ -246,7 +246,7 @@ function RemoveMemberForm({ teamId }: { teamId: string }) {
               max={newSignerCount}
               value={badgeThreshold || Math.min(team.threshold, newSignerCount)}
               onChange={(e) => setBadgeThreshold(e.target.value)}
-              className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+              className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring"
             />
             <p className="text-xs text-muted-foreground">
               Current threshold: {team.threshold}. After removal:{' '}
@@ -274,7 +274,7 @@ function RemoveMemberForm({ teamId }: { teamId: string }) {
                         [vault.accountAddress]: e.target.value
                       }))
                     }
-                    className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                    className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring"
                   />
                 </div>
               ))}
@@ -282,7 +282,10 @@ function RemoveMemberForm({ teamId }: { teamId: string }) {
           )}
 
           {error && (
-            <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-900">
+            <div
+              role="alert"
+              className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-900"
+            >
               {error}
             </div>
           )}

--- a/apps/client/src/routes/teams/$teamId/vaults/$vaultId/index.tsx
+++ b/apps/client/src/routes/teams/$teamId/vaults/$vaultId/index.tsx
@@ -1,4 +1,7 @@
 import { Result, useAtomRefresh, useAtomValue } from '@effect-atom/atom-react'
+import { useTeamName, useVaultName } from '@/hooks/useNames'
+import { AddressLink } from '@/components/AddressLink'
+import { RefreshCw } from 'lucide-react'
 import { VaultAddress } from '@radix-vaults/shared'
 import {
   createFileRoute,
@@ -40,21 +43,39 @@ export const Route = createFileRoute('/teams/$teamId/vaults/$vaultId/')({
 
 function VaultDetailPage() {
   const { teamId, vaultId } = Route.useParams()
+  const teamName = useTeamName(teamId)
+  const vaultName = useVaultName(teamId, vaultId)
 
   return (
     <main className="max-w-5xl space-y-6">
-      <div className="flex items-center justify-between gap-4">
-        <nav className="text-sm text-muted-foreground">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <nav className="text-sm text-muted-foreground sm:min-h-10 flex items-center flex-wrap">
           <Link to="/" className="hover:text-foreground">
-            Home
+            My Teams
           </Link>
           <span className="mx-2">/</span>
-          <span className="text-foreground font-medium">Vault</span>
+          <Link
+            to="/teams/$teamId"
+            params={{ teamId }}
+            className="hover:text-foreground"
+          >
+            {teamName}
+          </Link>
+          <span className="mx-2">/</span>
+          <Link
+            to="/teams/$teamId/vaults"
+            params={{ teamId }}
+            className="hover:text-foreground"
+          >
+            Vaults
+          </Link>
+          <span className="mx-2">/</span>
+          <span className="text-foreground font-medium">{vaultName}</span>
         </nav>
         <ClientOnly
           fallback={
             <Button variant="outline" disabled>
-              Refresh
+              <RefreshCw className="h-4 w-4" />
             </Button>
           }
         >
@@ -96,7 +117,7 @@ function RefreshVaultButton() {
 
   return (
     <Button variant="outline" onClick={refresh}>
-      Refresh
+      <RefreshCw className="h-4 w-4" />
     </Button>
   )
 }
@@ -131,8 +152,8 @@ function VaultReadContent() {
         <Card>
           <CardHeader>
             <CardTitle className="text-2xl">{detail.name}</CardTitle>
-            <CardDescription className="font-mono text-xs">
-              {detail.accountAddress}
+            <CardDescription>
+              <AddressLink address={detail.accountAddress} />
             </CardDescription>
           </CardHeader>
           <CardContent className="grid gap-3 sm:grid-cols-3">
@@ -247,7 +268,7 @@ function ProposalListSection() {
     .onFailure(() => null)
     .onSuccess((proposals) => (
       <Card>
-        <CardHeader className="flex flex-row items-center justify-between">
+        <CardHeader className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
           <div>
             <CardTitle>Proposals</CardTitle>
             <CardDescription>

--- a/apps/client/src/routes/teams/$teamId/vaults/$vaultId/index.tsx
+++ b/apps/client/src/routes/teams/$teamId/vaults/$vaultId/index.tsx
@@ -74,7 +74,7 @@ function VaultDetailPage() {
         </nav>
         <ClientOnly
           fallback={
-            <Button variant="outline" disabled>
+            <Button variant="outline" disabled aria-label="Refresh">
               <RefreshCw className="h-4 w-4" />
             </Button>
           }
@@ -116,7 +116,7 @@ function RefreshVaultButton() {
   )
 
   return (
-    <Button variant="outline" onClick={refresh}>
+    <Button variant="outline" onClick={refresh} aria-label="Refresh">
       <RefreshCw className="h-4 w-4" />
     </Button>
   )
@@ -294,8 +294,12 @@ function ProposalListSection() {
                 <TableRow>
                   <TableHead>ID</TableHead>
                   <TableHead>Status</TableHead>
-                  <TableHead>Created By</TableHead>
-                  <TableHead>Created</TableHead>
+                  <TableHead className="hidden sm:table-cell">
+                    Created By
+                  </TableHead>
+                  <TableHead className="hidden sm:table-cell">
+                    Created
+                  </TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -303,12 +307,23 @@ function ProposalListSection() {
                   <TableRow
                     key={p.id}
                     className="cursor-pointer"
+                    tabIndex={0}
+                    role="link"
                     onClick={() =>
                       navigate({
                         to: '/teams/$teamId/vaults/$vaultId/proposals/$proposalId',
                         params: { teamId, vaultId, proposalId: String(p.id) }
                       })
                     }
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        navigate({
+                          to: '/teams/$teamId/vaults/$vaultId/proposals/$proposalId',
+                          params: { teamId, vaultId, proposalId: String(p.id) }
+                        })
+                      }
+                    }}
                   >
                     <TableCell>
                       <Link
@@ -324,10 +339,10 @@ function ProposalListSection() {
                         {p.status}
                       </Badge>
                     </TableCell>
-                    <TableCell className="font-mono text-xs">
+                    <TableCell className="hidden sm:table-cell font-mono text-xs">
                       {p.createdByName ?? `${p.createdBy.slice(0, 20)}...`}
                     </TableCell>
-                    <TableCell className="text-xs text-muted-foreground">
+                    <TableCell className="hidden sm:table-cell text-xs text-muted-foreground">
                       {new Date(p.createdAt).toLocaleString()}
                     </TableCell>
                   </TableRow>

--- a/apps/client/src/routes/teams/$teamId/vaults/$vaultId/proposals/$proposalId.tsx
+++ b/apps/client/src/routes/teams/$teamId/vaults/$vaultId/proposals/$proposalId.tsx
@@ -9,6 +9,9 @@ import type { ProposalDetail } from '@radix-vaults/shared'
 import { ProposalId, VaultAddress } from '@radix-vaults/shared'
 import { createFileRoute, Link, ClientOnly } from '@tanstack/react-router'
 import { Exit } from 'effect'
+import { useTeamName, useVaultName } from '@/hooks/useNames'
+import { AddressLink } from '@/components/AddressLink'
+import { RefreshCw } from 'lucide-react'
 import { sessionAtom } from '@/atom/auth'
 import {
   ProposalDetailKey,
@@ -45,12 +48,30 @@ export const Route = createFileRoute(
 
 function ProposalDetailPage() {
   const { teamId, vaultId, proposalId } = Route.useParams()
+  const teamName = useTeamName(teamId)
+  const vaultName = useVaultName(teamId, vaultId)
 
   return (
     <main className="max-w-5xl space-y-6">
-      <nav className="text-sm text-muted-foreground">
+      <nav className="text-sm text-muted-foreground sm:min-h-10 flex items-center flex-wrap">
         <Link to="/" className="hover:text-foreground">
-          Home
+          My Teams
+        </Link>
+        <span className="mx-2">/</span>
+        <Link
+          to="/teams/$teamId"
+          params={{ teamId }}
+          className="hover:text-foreground"
+        >
+          {teamName}
+        </Link>
+        <span className="mx-2">/</span>
+        <Link
+          to="/teams/$teamId/vaults"
+          params={{ teamId }}
+          className="hover:text-foreground"
+        >
+          Vaults
         </Link>
         <span className="mx-2">/</span>
         <Link
@@ -58,7 +79,7 @@ function ProposalDetailPage() {
           params={{ teamId, vaultId }}
           className="hover:text-foreground"
         >
-          Vault
+          {vaultName}
         </Link>
         <span className="mx-2">/</span>
         <span className="text-foreground font-medium">
@@ -147,17 +168,17 @@ function ProposalDetailContent() {
     .onSuccess((proposal) => (
       <>
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between">
+          <CardHeader className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
             <div>
               <CardTitle className="text-2xl">
                 Proposal #{proposal.id}
               </CardTitle>
-              <CardDescription className="font-mono text-xs">
-                {proposal.vaultAddress}
+              <CardDescription>
+                <AddressLink address={proposal.vaultAddress} />
               </CardDescription>
             </div>
             <Button variant="outline" onClick={refresh}>
-              Refresh
+              <RefreshCw className="h-4 w-4" />
             </Button>
           </CardHeader>
           <CardContent className="grid gap-3 sm:grid-cols-3">
@@ -298,7 +319,7 @@ function SignatureProgressCard({
 
   return (
     <Card>
-      <CardHeader className="flex flex-row items-center justify-between">
+      <CardHeader className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div>
           <CardTitle>Signature Progress</CardTitle>
           <CardDescription>
@@ -387,7 +408,7 @@ function SubmitCard({
 
   return (
     <Card className="border-green-200 bg-green-50/80">
-      <CardHeader className="flex flex-row items-center justify-between">
+      <CardHeader className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div>
           <CardTitle>Ready to Submit</CardTitle>
           <CardDescription>
@@ -445,7 +466,7 @@ function TransactionInfoCard({
 
   return (
     <Card>
-      <CardHeader className="flex flex-row items-center justify-between">
+      <CardHeader className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div>
           <CardTitle>Transaction</CardTitle>
           <CardDescription>

--- a/apps/client/src/routes/teams/$teamId/vaults/$vaultId/proposals/$proposalId.tsx
+++ b/apps/client/src/routes/teams/$teamId/vaults/$vaultId/proposals/$proposalId.tsx
@@ -177,7 +177,7 @@ function ProposalDetailContent() {
                 <AddressLink address={proposal.vaultAddress} />
               </CardDescription>
             </div>
-            <Button variant="outline" onClick={refresh}>
+            <Button variant="outline" onClick={refresh} aria-label="Refresh">
               <RefreshCw className="h-4 w-4" />
             </Button>
           </CardHeader>

--- a/apps/client/src/routes/teams/$teamId/vaults/$vaultId/proposals/new.tsx
+++ b/apps/client/src/routes/teams/$teamId/vaults/$vaultId/proposals/new.tsx
@@ -141,7 +141,7 @@ function NewProposalPage() {
                 placeholder={`CALL_METHOD\n  Address("...")\n  "deposit_batch"\n  Expression("ENTIRE_WORKTOP")\n;`}
                 value={manifest}
                 onChange={(e) => setManifest(e.target.value)}
-                className="w-full rounded-lg border border-input bg-card px-3 py-2 font-mono text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                className="w-full rounded-lg border border-input bg-card px-3 py-2 font-mono text-sm outline-none focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring"
               />
             </div>
 
@@ -157,7 +157,7 @@ function NewProposalPage() {
                 step={1}
                 value={expiresInHours}
                 onChange={(e) => setExpiresInHours(e.target.value)}
-                className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring"
               />
               <p className="text-xs text-muted-foreground">
                 Number of hours from now until this proposal expires.
@@ -165,7 +165,10 @@ function NewProposalPage() {
             </div>
 
             {error && (
-              <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-900">
+              <div
+                role="alert"
+                className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-900"
+              >
                 {error}
               </div>
             )}

--- a/apps/client/src/routes/teams/$teamId/vaults/$vaultId/proposals/new.tsx
+++ b/apps/client/src/routes/teams/$teamId/vaults/$vaultId/proposals/new.tsx
@@ -1,6 +1,7 @@
 import { useAtom, useAtomRefresh } from '@effect-atom/atom-react'
 import { VaultAddress } from '@radix-vaults/shared'
 import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
+import { useTeamName, useVaultName } from '@/hooks/useNames'
 import { Cause, Exit, Option } from 'effect'
 import { useState } from 'react'
 import {
@@ -27,6 +28,8 @@ export const Route = createFileRoute(
 function NewProposalPage() {
   const { teamId, vaultId } = Route.useParams()
   const navigate = useNavigate()
+  const teamName = useTeamName(teamId)
+  const vaultName = useVaultName(teamId, vaultId)
   const vaultAddress = VaultAddress.make(vaultId)
   const refreshProposals = useAtomRefresh(
     proposalListAtom(ProposalListKey({ teamId, vaultAddress }))
@@ -85,9 +88,25 @@ function NewProposalPage() {
 
   return (
     <main className="max-w-5xl space-y-6">
-      <nav className="text-sm text-muted-foreground">
+      <nav className="text-sm text-muted-foreground sm:min-h-10 flex items-center flex-wrap">
         <Link to="/" className="hover:text-foreground">
-          Home
+          My Teams
+        </Link>
+        <span className="mx-2">/</span>
+        <Link
+          to="/teams/$teamId"
+          params={{ teamId }}
+          className="hover:text-foreground"
+        >
+          {teamName}
+        </Link>
+        <span className="mx-2">/</span>
+        <Link
+          to="/teams/$teamId/vaults"
+          params={{ teamId }}
+          className="hover:text-foreground"
+        >
+          Vaults
         </Link>
         <span className="mx-2">/</span>
         <Link
@@ -95,7 +114,7 @@ function NewProposalPage() {
           params={{ teamId, vaultId }}
           className="hover:text-foreground"
         >
-          Vault
+          {vaultName}
         </Link>
         <span className="mx-2">/</span>
         <span className="text-foreground font-medium">New Proposal</span>
@@ -122,7 +141,7 @@ function NewProposalPage() {
                 placeholder={`CALL_METHOD\n  Address("...")\n  "deposit_batch"\n  Expression("ENTIRE_WORKTOP")\n;`}
                 value={manifest}
                 onChange={(e) => setManifest(e.target.value)}
-                className="w-full rounded-lg border border-input bg-white px-3 py-2 font-mono text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                className="w-full rounded-lg border border-input bg-card px-3 py-2 font-mono text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
               />
             </div>
 
@@ -138,7 +157,7 @@ function NewProposalPage() {
                 step={1}
                 value={expiresInHours}
                 onChange={(e) => setExpiresInHours(e.target.value)}
-                className="w-full rounded-lg border border-input bg-white px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
               />
               <p className="text-xs text-muted-foreground">
                 Number of hours from now until this proposal expires.

--- a/apps/client/src/routes/teams/$teamId/vaults/add.tsx
+++ b/apps/client/src/routes/teams/$teamId/vaults/add.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
 import { useAtom, useAtomRefresh } from '@effect-atom/atom-react'
 import { VaultAddress } from '@radix-vaults/shared'
+import { useTeamName } from '@/hooks/useNames'
 import { Exit } from 'effect'
 import { useState } from 'react'
 import { importVault, vaultsListAtom } from '@/atom/vaults'
@@ -20,6 +21,7 @@ export const Route = createFileRoute('/teams/$teamId/vaults/add')({
 function AddVaultPage() {
   const { teamId } = Route.useParams()
   const navigate = useNavigate()
+  const teamName = useTeamName(teamId)
   const refreshVaults = useAtomRefresh(vaultsListAtom(teamId))
   const [, dispatch] = useAtom(importVault, { mode: 'promiseExit' })
   const [accountAddress, setAccountAddress] = useState('')
@@ -62,9 +64,17 @@ function AddVaultPage() {
 
   return (
     <main className="max-w-5xl space-y-6">
-      <nav className="text-sm text-muted-foreground">
+      <nav className="text-sm text-muted-foreground sm:min-h-10 flex items-center flex-wrap">
         <Link to="/" className="hover:text-foreground">
-          Home
+          My Teams
+        </Link>
+        <span className="mx-2">/</span>
+        <Link
+          to="/teams/$teamId"
+          params={{ teamId }}
+          className="hover:text-foreground"
+        >
+          {teamName}
         </Link>
         <span className="mx-2">/</span>
         <Link
@@ -99,7 +109,7 @@ function AddVaultPage() {
                 placeholder="account_tdx_2_1..."
                 value={accountAddress}
                 onChange={(e) => setAccountAddress(e.target.value)}
-                className="w-full rounded-lg border border-input bg-white px-3 py-2 font-mono text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                className="w-full rounded-lg border border-input bg-card px-3 py-2 font-mono text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
               />
             </div>
 
@@ -115,7 +125,7 @@ function AddVaultPage() {
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 maxLength={255}
-                className="w-full rounded-lg border border-input bg-white px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
               />
             </div>
 

--- a/apps/client/src/routes/teams/$teamId/vaults/add.tsx
+++ b/apps/client/src/routes/teams/$teamId/vaults/add.tsx
@@ -109,7 +109,7 @@ function AddVaultPage() {
                 placeholder="account_tdx_2_1..."
                 value={accountAddress}
                 onChange={(e) => setAccountAddress(e.target.value)}
-                className="w-full rounded-lg border border-input bg-card px-3 py-2 font-mono text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                className="w-full rounded-lg border border-input bg-card px-3 py-2 font-mono text-sm outline-none focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring"
               />
             </div>
 
@@ -125,12 +125,15 @@ function AddVaultPage() {
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 maxLength={255}
-                className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring"
               />
             </div>
 
             {error && (
-              <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-900">
+              <div
+                role="alert"
+                className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-900"
+              >
                 {error}
               </div>
             )}

--- a/apps/client/src/routes/teams/$teamId/vaults/create.tsx
+++ b/apps/client/src/routes/teams/$teamId/vaults/create.tsx
@@ -106,7 +106,7 @@ function CreateVaultPage() {
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 maxLength={255}
-                className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring"
               />
             </div>
 
@@ -121,7 +121,7 @@ function CreateVaultPage() {
                 min={1}
                 value={threshold}
                 onChange={(e) => setThreshold(Number(e.target.value))}
-                className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring"
               />
               <p className="text-xs text-muted-foreground">
                 Vault will use your team&apos;s current signer set. The
@@ -130,7 +130,10 @@ function CreateVaultPage() {
             </div>
 
             {error && (
-              <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-900">
+              <div
+                role="alert"
+                className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-900"
+              >
                 {error}
               </div>
             )}

--- a/apps/client/src/routes/teams/$teamId/vaults/create.tsx
+++ b/apps/client/src/routes/teams/$teamId/vaults/create.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
 import { useAtom, useAtomRefresh } from '@effect-atom/atom-react'
 import { Exit } from 'effect'
+import { useTeamName } from '@/hooks/useNames'
 import { useState } from 'react'
 import { createVault, vaultsListAtom } from '@/atom/vaults'
 import { Button } from '@/components/ui/button'
@@ -19,6 +20,7 @@ export const Route = createFileRoute('/teams/$teamId/vaults/create')({
 function CreateVaultPage() {
   const { teamId } = Route.useParams()
   const navigate = useNavigate()
+  const teamName = useTeamName(teamId)
   const refreshVaults = useAtomRefresh(vaultsListAtom(teamId))
   const [, dispatch] = useAtom(createVault, { mode: 'promiseExit' })
   const [name, setName] = useState('')
@@ -58,9 +60,17 @@ function CreateVaultPage() {
 
   return (
     <main className="max-w-5xl space-y-6">
-      <nav className="text-sm text-muted-foreground">
+      <nav className="text-sm text-muted-foreground sm:min-h-10 flex items-center flex-wrap">
         <Link to="/" className="hover:text-foreground">
-          Home
+          My Teams
+        </Link>
+        <span className="mx-2">/</span>
+        <Link
+          to="/teams/$teamId"
+          params={{ teamId }}
+          className="hover:text-foreground"
+        >
+          {teamName}
         </Link>
         <span className="mx-2">/</span>
         <Link
@@ -96,7 +106,7 @@ function CreateVaultPage() {
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 maxLength={255}
-                className="w-full rounded-lg border border-input bg-white px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
               />
             </div>
 
@@ -111,7 +121,7 @@ function CreateVaultPage() {
                 min={1}
                 value={threshold}
                 onChange={(e) => setThreshold(Number(e.target.value))}
-                className="w-full rounded-lg border border-input bg-white px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
               />
               <p className="text-xs text-muted-foreground">
                 Vault will use your team&apos;s current signer set. The

--- a/apps/client/src/routes/teams/$teamId/vaults/index.tsx
+++ b/apps/client/src/routes/teams/$teamId/vaults/index.tsx
@@ -2,6 +2,8 @@ import { Link, ClientOnly, createFileRoute } from '@tanstack/react-router'
 import { Result, useAtomRefresh, useAtomValue } from '@effect-atom/atom-react'
 import { sessionAtom } from '@/atom/auth'
 import { vaultsListAtom } from '@/atom/vaults'
+import { useTeamName } from '@/hooks/useNames'
+import { AddressLink } from '@/components/AddressLink'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -20,12 +22,21 @@ export const Route = createFileRoute('/teams/$teamId/vaults/')({
 
 function VaultsPage() {
   const { teamId } = Route.useParams()
+  const teamName = useTeamName(teamId)
 
   return (
     <main className="max-w-5xl space-y-6">
-      <nav className="text-sm text-muted-foreground">
+      <nav className="text-sm text-muted-foreground sm:min-h-10 flex items-center flex-wrap">
         <Link to="/" className="hover:text-foreground">
-          Home
+          My Teams
+        </Link>
+        <span className="mx-2">/</span>
+        <Link
+          to="/teams/$teamId"
+          params={{ teamId }}
+          className="hover:text-foreground"
+        >
+          {teamName}
         </Link>
         <span className="mx-2">/</span>
         <span className="text-foreground font-medium">Vaults</span>
@@ -69,7 +80,7 @@ function VaultHeader({ teamId }: { teamId: string }) {
   }
 
   return (
-    <CardHeader className="flex flex-row items-start justify-between gap-4">
+    <CardHeader className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
       <div>
         <CardTitle className="text-2xl">Vaults</CardTitle>
         <CardDescription>Manage your multisig vaults.</CardDescription>
@@ -78,13 +89,13 @@ function VaultHeader({ teamId }: { teamId: string }) {
         <Link to="/teams/$teamId/vaults/create" params={{ teamId }}>
           <Button size="sm">
             <PlusCircle className="mr-1.5 h-4 w-4" />
-            Create Vault
+            Create
           </Button>
         </Link>
         <Link to="/teams/$teamId/vaults/add" params={{ teamId }}>
           <Button variant="outline" size="sm">
             <Download className="mr-1.5 h-4 w-4" />
-            Import Vault
+            Import
           </Button>
         </Link>
       </div>
@@ -141,9 +152,12 @@ function VaultsList({ teamId }: { teamId: string }) {
                     <h2 className="truncate text-base font-semibold">
                       {vault.name}
                     </h2>
-                    <p className="mt-1 truncate font-mono text-xs text-muted-foreground">
-                      {vault.accountAddress}
-                    </p>
+                    <span
+                      className="mt-1 block"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <AddressLink address={vault.accountAddress} />
+                    </span>
                   </div>
                   <Badge variant="secondary">
                     {vault.pendingProposalCount} pending

--- a/apps/client/src/routes/teams/create.tsx
+++ b/apps/client/src/routes/teams/create.tsx
@@ -61,9 +61,9 @@ function CreateTeamPage() {
 
   return (
     <main className="max-w-5xl space-y-6">
-      <nav className="text-sm text-muted-foreground">
+      <nav className="text-sm text-muted-foreground sm:min-h-10 flex items-center flex-wrap">
         <Link to="/" className="hover:text-foreground">
-          Home
+          My Teams
         </Link>
         <span className="mx-2">/</span>
         <span className="text-foreground font-medium">Create Team</span>
@@ -91,7 +91,7 @@ function CreateTeamPage() {
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 maxLength={255}
-                className="w-full rounded-lg border border-input bg-white px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
               />
             </div>
 
@@ -106,7 +106,7 @@ function CreateTeamPage() {
                 placeholder="resource_tdx_2_...:..."
                 value={virtualBadge}
                 onChange={(e) => setVirtualBadge(e.target.value)}
-                className="w-full rounded-lg border border-input bg-white px-3 py-2 text-sm font-mono text-xs outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm font-mono text-xs outline-none focus:border-ring focus:ring-1 focus:ring-ring"
               />
               <p className="text-xs text-muted-foreground">
                 Your virtual signature badge NonFungibleGlobalId (e.g.
@@ -126,7 +126,7 @@ function CreateTeamPage() {
                 value={memberName}
                 onChange={(e) => setMemberName(e.target.value)}
                 maxLength={100}
-                className="w-full rounded-lg border border-input bg-white px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
               />
               <p className="text-xs text-muted-foreground">
                 Display name stored in the NFT badge metadata.

--- a/apps/client/src/routes/teams/create.tsx
+++ b/apps/client/src/routes/teams/create.tsx
@@ -91,7 +91,7 @@ function CreateTeamPage() {
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 maxLength={255}
-                className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring"
               />
             </div>
 
@@ -106,7 +106,7 @@ function CreateTeamPage() {
                 placeholder="resource_tdx_2_...:..."
                 value={virtualBadge}
                 onChange={(e) => setVirtualBadge(e.target.value)}
-                className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm font-mono text-xs outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm font-mono text-xs outline-none focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring"
               />
               <p className="text-xs text-muted-foreground">
                 Your virtual signature badge NonFungibleGlobalId (e.g.
@@ -126,7 +126,7 @@ function CreateTeamPage() {
                 value={memberName}
                 onChange={(e) => setMemberName(e.target.value)}
                 maxLength={100}
-                className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                className="w-full rounded-lg border border-input bg-card px-3 py-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring"
               />
               <p className="text-xs text-muted-foreground">
                 Display name stored in the NFT badge metadata.
@@ -134,7 +134,10 @@ function CreateTeamPage() {
             </div>
 
             {error && (
-              <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-900">
+              <div
+                role="alert"
+                className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-900"
+              >
                 {error}
               </div>
             )}

--- a/apps/client/src/styles.css
+++ b/apps/client/src/styles.css
@@ -15,7 +15,7 @@
   --secondary: oklch(0.965 0 0);
   --secondary-foreground: oklch(0.2 0 0);
   --muted: oklch(0.965 0 0);
-  --muted-foreground: oklch(0.55 0 0);
+  --muted-foreground: oklch(0.46 0 0);
   --accent: oklch(0.965 0 0);
   --accent-foreground: oklch(0.2 0 0);
   --destructive: oklch(0.577 0.245 27.325);
@@ -40,40 +40,6 @@
   --sidebar-ring: oklch(0.87 0 0);
 }
 
-.dark {
-  --background: oklch(0.16 0 0);
-  --foreground: oklch(0.97 0 0);
-  --card: oklch(0.23 0 0);
-  --card-foreground: oklch(0.97 0 0);
-  --popover: oklch(0.23 0 0);
-  --popover-foreground: oklch(0.97 0 0);
-  --primary: oklch(0.97 0 0);
-  --primary-foreground: oklch(0.16 0 0);
-  --secondary: oklch(0.25 0 0);
-  --secondary-foreground: oklch(0.97 0 0);
-  --muted: oklch(0.25 0 0);
-  --muted-foreground: oklch(0.63 0 0);
-  --accent: oklch(0.25 0 0);
-  --accent-foreground: oklch(0.97 0 0);
-  --destructive: oklch(0.396 0.141 25.723);
-  --destructive-foreground: oklch(0.637 0.237 25.331);
-  --border: oklch(0.30 0 0);
-  --input: oklch(0.30 0 0);
-  --ring: oklch(0.4 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.19 0 0);
-  --sidebar-foreground: oklch(0.97 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.97 0 0);
-  --sidebar-accent: oklch(0.25 0 0);
-  --sidebar-accent-foreground: oklch(0.97 0 0);
-  --sidebar-border: oklch(0.30 0 0);
-  --sidebar-ring: oklch(0.4 0 0);
-}
 
 @theme inline {
   --color-background: var(--background);
@@ -236,7 +202,7 @@ h1, h2, h3, h4, h5, h6 {
   padding: 0.5rem 0.875rem;
   font-size: 13.5px;
   font-weight: 500;
-  color: oklch(0.50 0.01 55);
+  color: oklch(0.58 0.01 55);
   transition: color 150ms ease, background 150ms ease;
   position: relative;
 }
@@ -322,13 +288,13 @@ h1, h2, h3, h4, h5, h6 {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  color: oklch(0.40 0.015 55);
+  color: oklch(0.52 0.015 55);
   padding: 1.25rem 0.875rem 0.5rem;
   transition: color 150ms ease;
 }
 
 .sidebar-section-link:hover {
-  color: oklch(0.58 0.015 55);
+  color: oklch(0.65 0.015 55);
 }
 
 .sidebar-section-link.active {
@@ -362,7 +328,7 @@ h1, h2, h3, h4, h5, h6 {
 .sidebar-chevron {
   width: 11px !important;
   height: 11px !important;
-  opacity: 0.30;
+  opacity: 0.40;
   transition: transform 200ms ease, opacity 200ms ease;
 }
 

--- a/apps/client/src/styles.css
+++ b/apps/client/src/styles.css
@@ -141,19 +141,72 @@ h1, h2, h3, h4, h5, h6 {
 
 .app-shell {
   display: flex;
-  min-height: 100vh;
+  height: 100vh;
+  overflow: hidden;
   padding: 0;
 }
 
+@media (max-width: 1023px) {
+  .sidebar {
+    position: fixed !important;
+    width: 256px;
+    min-width: 0;
+    flex: 0 0 0px;
+  }
+}
+
 .sidebar {
-  width: 240px;
-  min-width: 240px;
-  background: linear-gradient(180deg, oklch(0.14 0.005 155), oklch(0.11 0.005 155));
-  border-right: 1px solid oklch(0.22 0.01 155);
+  width: 256px;
+  min-width: 256px;
+  background: linear-gradient(180deg, oklch(0.13 0.012 55), oklch(0.10 0.012 55));
+  border-right: 1px solid oklch(0.20 0.015 55);
   display: flex;
   flex-direction: column;
   height: 100vh;
   overflow: hidden;
+  position: relative;
+}
+
+
+.sidebar::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");
+  background-repeat: repeat;
+  background-size: 200px 200px;
+  pointer-events: none;
+  z-index: 0;
+  mix-blend-mode: overlay;
+}
+
+.sidebar > * {
+  position: relative;
+  z-index: 1;
+}
+
+/* ── Sidebar scrollbar ── */
+
+.sidebar *::-webkit-scrollbar {
+  width: 4px;
+}
+
+.sidebar *::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.sidebar *::-webkit-scrollbar-thumb {
+  background: oklch(0.25 0.01 55);
+  border-radius: 2px;
+}
+
+.sidebar *::-webkit-scrollbar-thumb:hover {
+  background: oklch(0.35 0.01 55);
+}
+
+.sidebar * {
+  scrollbar-width: thin;
+  scrollbar-color: oklch(0.25 0.01 55) transparent;
 }
 
 /* ── Sidebar keyframes ── */
@@ -174,132 +227,197 @@ h1, h2, h3, h4, h5, h6 {
   to { opacity: 1; transform: translateX(0); }
 }
 
-/* ── Sidebar nav items ── */
+/* ── Sidebar rows (shared base) ── */
 
-.sidebar-nav-item {
+.sidebar-row {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  border-radius: 0.5rem;
-  padding: 0.625rem 0.75rem;
-  font-size: 13px;
+  gap: 0.5rem;
+  padding: 0.5rem 0.875rem;
+  font-size: 13.5px;
   font-weight: 500;
-  color: oklch(0.65 0 0);
-  transition: all 200ms ease;
+  color: oklch(0.50 0.01 55);
+  transition: color 150ms ease, background 150ms ease;
   position: relative;
 }
 
-.sidebar-nav-item:hover {
-  background: oklch(0.18 0 0);
-  color: oklch(0.85 0 0);
+.sidebar-row:hover {
+  color: oklch(0.75 0.01 55);
+  background: oklch(1 0.01 55 / 0.05);
 }
 
-.sidebar-nav-item:hover .sidebar-nav-icon {
-  opacity: 1;
+/* ── Row variants ── */
+
+.sidebar-row--child {
+  padding-left: 2.25rem;
+  font-size: 12.5px;
+  font-weight: 400;
 }
 
-.sidebar-nav-item.active {
-  background: oklch(0.22 0.03 155);
-  color: oklch(0.95 0 0);
+.sidebar-row--leaf {
+  padding-left: calc(2.25rem + 22px + 0.5rem);
 }
 
-.sidebar-nav-item.active::before {
+.sidebar-row--vault {
+  padding-left: calc(2.25rem + 22px + 0.5rem + 1rem);
+  font-size: 12px;
+  font-weight: 400;
+}
+
+/* ── Active: team (warm white, bold accent bar) ── */
+
+.sidebar-row--team.active {
+  color: oklch(0.93 0.01 55);
+  background: oklch(1 0.01 55 / 0.08);
+}
+
+.sidebar-row--team.active::before {
   content: '';
   position: absolute;
   left: 0;
-  top: 4px;
-  bottom: 4px;
-  width: 2px;
-  border-radius: 1px;
+  top: 0.25rem;
+  bottom: 0.25rem;
+  width: 3px;
+  border-radius: 0 2px 2px 0;
   background: var(--color-safe-green);
 }
 
-.sidebar-nav-icon {
-  width: 18px;
-  height: 18px;
+/* ── Active: child (muted warm green) ── */
+
+.sidebar-row--child.active {
+  color: oklch(0.70 0.06 145);
+  background: oklch(1 0.01 55 / 0.04);
+}
+
+/* ── Active: vault (subtle warm green) ── */
+
+.sidebar-row--vault.active {
+  color: oklch(0.65 0.06 145);
+  background: oklch(1 0.01 55 / 0.03);
+}
+
+/* ── Icons ── */
+
+.sidebar-icon {
+  width: 16px;
+  height: 16px;
   flex-shrink: 0;
-  opacity: 0.55;
-  transition: opacity 200ms ease;
+  opacity: 0.40;
+  transition: opacity 150ms ease;
 }
 
-.sidebar-nav-item.active .sidebar-nav-icon {
-  opacity: 1;
+.sidebar-row.active .sidebar-icon {
+  opacity: 0.9;
 }
 
-.sidebar-nav-nested {
-  padding-left: 2.25rem;
+.sidebar-row:hover .sidebar-icon {
+  opacity: 0.65;
 }
 
-.sidebar-nav-nested.active::before,
-.sidebar-nav-vault.active::before {
-  display: none;
-}
-
-.sidebar-nav-vault {
-  padding-left: 3.25rem;
-  font-size: 12px;
-}
-
-/* ── Sidebar section label ── */
+/* ── Section label (clickable → home) ── */
 
 .sidebar-section-label {
-  font-size: 10px;
+  display: block;
+  font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: oklch(0.45 0 0);
-  padding: 1rem 0.75rem 0.375rem;
+  letter-spacing: 0.12em;
+  color: oklch(0.40 0.015 55);
+  padding: 1.25rem 0.875rem 0.5rem;
+  transition: color 150ms ease;
+}
+
+.sidebar-section-link:hover {
+  color: oklch(0.58 0.015 55);
+}
+
+.sidebar-section-link.active {
+  color: oklch(0.52 0.06 145);
 }
 
 /* ── Team group ── */
 
 .sidebar-team-group {
-  border-radius: 0.5rem;
-  transition: background 200ms ease;
+  margin-bottom: 0.25rem;
 }
 
-.sidebar-team-group.expanded {
-  background: oklch(1 0 0 / 0.12);
-  margin-block: 0.125rem;
-}
+/* ── Chevron area (click target for expand/collapse) ── */
 
-/* ── Team toggle button ── */
-
-.sidebar-team-toggle {
-  width: 100%;
+.sidebar-chevron-area {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+  border-radius: 4px;
   cursor: pointer;
-  background: none;
-  border: none;
-  text-align: left;
-  font-family: inherit;
+  transition: background 150ms ease;
+}
+
+.sidebar-chevron-area:hover {
+  background: oklch(1 0.01 55 / 0.1);
 }
 
 .sidebar-chevron {
-  width: 14px !important;
-  height: 14px !important;
-  opacity: 0.4;
+  width: 11px !important;
+  height: 11px !important;
+  opacity: 0.30;
   transition: transform 200ms ease, opacity 200ms ease;
-  flex-shrink: 0;
-  margin-right: -0.25rem;
 }
 
 .sidebar-chevron.expanded {
   transform: rotate(90deg);
+  opacity: 0.45;
 }
 
-.sidebar-team-toggle:hover .sidebar-chevron {
-  opacity: 0.7;
+.sidebar-chevron-area:hover .sidebar-chevron {
+  opacity: 0.6;
+}
+
+/* ── Row link (fills remaining space) ── */
+
+.sidebar-row-link {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1;
+  min-width: 0;
+}
+
+/* ── Children container with guide line ── */
+
+.sidebar-children {
+  position: relative;
+  padding-top: 0.125rem;
+  padding-bottom: 0.125rem;
+}
+
+.sidebar-children:not(.sidebar-children--deep)::before {
+  content: '';
+  position: absolute;
+  left: 1.5rem;
+  top: 0;
+  bottom: 0.25rem;
+  width: 1.5px;
+  border-radius: 1px;
+  background: oklch(0.20 0.015 55);
+  transition: background 200ms ease;
+}
+
+.sidebar-children.active:not(.sidebar-children--deep)::before {
+  background: oklch(0.30 0.04 145);
 }
 
 /* ── Vault card glass-morphism ── */
 
 .vault-card {
-  background: oklch(1 0 0 / 0.06);
+  background: oklch(1 0.01 55 / 0.06);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
-  border: 1px solid oklch(1 0 0 / 0.08);
+  border: 1px solid oklch(1 0.01 55 / 0.1);
   border-radius: 0.625rem;
-  padding: 0.875rem;
+  padding: 1rem;
 }
 
 .vault-card-btn {
@@ -329,15 +447,19 @@ h1, h2, h3, h4, h5, h6 {
   min-height: 100vh;
 }
 
+.main-content main {
+  margin-inline: auto;
+}
+
 .top-bar {
-  height: 56px;
-  background: white;
+  height: 64px;
+  background: var(--card);
   border-bottom: 1px solid var(--border);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.03);
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  padding: 0 1.5rem;
+  padding: 0 2rem;
   position: sticky;
   top: 0;
   z-index: 10;

--- a/apps/server/src/gateway/manifests.test.ts
+++ b/apps/server/src/gateway/manifests.test.ts
@@ -14,6 +14,7 @@ describe('buildCreateTeamBadgeManifest', () => {
         'resource_tdx_2_1nfxxxxxxxxxxsgnvbdge_ed25sg:[abcdef1234567890]',
       creatorAccount: 'account_tdx_2_creator',
       memberName: 'Alice',
+      teamName: 'My Team',
       teamId: 'test-team-uuid',
       networkId: 2
     })
@@ -53,6 +54,7 @@ describe('buildCreateTeamBadgeManifest', () => {
         'resource_tdx_2_1nfxxxxxxxxxxsgnvbdge_ed25sg:[aabbccdd]',
       creatorAccount: 'account_tdx_2_creator',
       memberName: 'Bob',
+      teamName: 'Bob Team',
       teamId: 'team-123',
       networkId: 2
     })
@@ -73,6 +75,7 @@ describe('buildCreateTeamBadgeManifest', () => {
         'resource_tdx_2_1nfxxxxxxxxxxsgnvbdge_ed25sg:[aabbccdd]',
       creatorAccount: 'account_tdx_2_creator',
       memberName: 'Carol',
+      teamName: 'Carol Team',
       teamId: 'team-456',
       networkId: 2
     })

--- a/apps/server/src/gateway/manifests.ts
+++ b/apps/server/src/gateway/manifests.ts
@@ -254,6 +254,7 @@ export async function buildCreateTeamBadgeManifest(input: {
   creatorVirtualBadge: string
   creatorAccount: string
   memberName: string
+  teamName: string
   teamId: string
   networkId: number
 }): Promise<string> {
@@ -341,7 +342,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
     )
     Tuple(
         Map<String, Tuple>(
-            "name" => Tuple(Enum<1u8>(Enum<0u8>("${input.memberName} Team Badge")), true)
+            "name" => Tuple(Enum<1u8>(Enum<0u8>("${input.teamName} Team Badge")), true)
         ),
         Map<String, Enum>()
     )

--- a/apps/server/src/handlers/teams.ts
+++ b/apps/server/src/handlers/teams.ts
@@ -32,6 +32,7 @@ export class TeamsHandler extends Effect.Service<TeamsHandler>()(
               creatorVirtualBadge: virtualBadge,
               creatorAccount: creatorAccountAddress,
               memberName,
+              teamName: name,
               teamId,
               networkId: authConfig.networkId
             })


### PR DESCRIPTION
made a couple of changes, feel free to revert any, some border on personal preference:
- changed team badge name to TEAM's name instead of first member's name
- changed rdt requested accounts to exactly one, instead of at least one (only one was used anyways)
- centered page contents, whereas everything was aligned to the left previously
- made breadcrumb more accurate
- fixed many issues in mobile view
- shortened some button labels (pretty much necessary for mobile)
- introduced account address / resource address truncation + redirect abstraction
- added "create vault" option under vaults collapsible in side nav bar
- vertically centered buttons on the CardHeader components
- overall changes to aesthetic
- current vault name shows proper vault name now
- changed refresh buttons to icon only
- made entire proposal row clickable, instead of id only